### PR TITLE
tscとlintとprittierをいい感じにした

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,5 @@
     "jest-svg-transformer": "^1.0.0",
     "prettier": "^2.4.1",
     "ts-jest": "26.5.0"
-  },
+  }
 }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "format": "prettier --check `src/**/*.{jsx,js,tsx,ts,css,scss,md,json}`",
-    "lint": "eslint 'src/**/*.{jsx,js,tsx,ts}'",
-    "lint:fix": "eslint --fix 'src/**/*.{jsx,js,tsx,ts}' && prettier --write .",
+    "lint": "eslint `src/**/*.{jsx,js,tsx,ts}`",
+    "lint:fix": "eslint --fix `src/**/*.{jsx,js,tsx,ts}` && prettier --write .",
     "format:fix": "prettier --write `src/**/*.{jsx,js,tsx,ts,css,scss,md,json}`",
     "typecheck": "yarn tsc --noEmit `src/*.{ts,tsx}`"
   },
@@ -55,5 +55,5 @@
     "jest-svg-transformer": "^1.0.0",
     "prettier": "^2.4.1",
     "ts-jest": "26.5.0"
-  }
+  },
 }

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "format": "prettier --check src/**/*.{jsx,js,tsx,ts,css,scss,md,json}",
-    "lint": "eslint src/**/*.{jsx,js,tsx,ts}",
-    "lint:fix": "eslint --fix src/**/*.{jsx,js,tsx,ts} && prettier --write .",
-    "format:fix": "prettier --write src/**/*.{jsx,js,tsx,ts,css,scss,md,json}"
+    "format": "prettier --check `src/**/*.{jsx,js,tsx,ts,css,scss,md,json}`",
+    "lint": "eslint 'src/**/*.{jsx,js,tsx,ts}'",
+    "lint:fix": "eslint --fix 'src/**/*.{jsx,js,tsx,ts}' && prettier --write .",
+    "format:fix": "prettier --write `src/**/*.{jsx,js,tsx,ts,css,scss,md,json}`",
+    "typecheck": "yarn tsc --noEmit `src/*.ts`"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "eslint 'src/**/*.{jsx,js,tsx,ts}'",
     "lint:fix": "eslint --fix 'src/**/*.{jsx,js,tsx,ts}' && prettier --write .",
     "format:fix": "prettier --write `src/**/*.{jsx,js,tsx,ts,css,scss,md,json}`",
-    "typecheck": "yarn tsc --noEmit `src/*.ts`"
+    "typecheck": "yarn tsc --noEmit `src/*.{ts,tsx}`"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
yarn typecheckでtscをsrc/*{.ts,.tsx}にかける（.js生成なし）
yarn lint:fixでprittierとlintどっちも動くけど正規表現がシングルクォーテーションで囲ってないとだめだったので囲っときました．winで動くかはわからない