### PR TITLE
Feature/moreroomrtc

### DIFF
--- a/src/axios_config.ts
+++ b/src/axios_config.ts
@@ -1,0 +1,35 @@
+import axios, { Axios } from "axios";
+import { uri } from "config";
+import { getIdToken } from "firebase_config";
+
+axios.defaults.baseURL = uri;
+
+// APIへのアクセスだけなのでjsonに絞る
+const instance: Axios = axios.create({
+  headers: {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  },
+});
+
+// アクセスの度に実行される
+instance.interceptors.request.use(
+  async (config) => {
+    //tokenを取得
+    const token = await getIdToken();
+    //tokenをヘッダーに設定
+    if (token) {
+      if (!config.headers) config.headers = {};
+      config.headers["Authorization"] = `Bearer ${token}`;
+    } else {
+      if (config.headers) delete config.headers["Authorization"];
+    }
+
+    return config;
+  },
+  (error: any) => {
+    return Promise.reject(error);
+  }
+);
+
+export const axiosWithIdToken = instance;

--- a/src/firebase_config.ts
+++ b/src/firebase_config.ts
@@ -2,6 +2,11 @@ import firebase from "firebase/compat/app";
 import "firebase/compat/auth";
 
 import { firebaseConfig } from "config";
+import { getAuth } from "firebase/auth";
 
 //firebaseの初期化
 firebase.initializeApp(firebaseConfig);
+
+export const getIdToken = async () => {
+  return getAuth().currentUser?.getIdToken();
+};

--- a/src/hooks/CodeAPIHooks/useFetchCodes.test.ts
+++ b/src/hooks/CodeAPIHooks/useFetchCodes.test.ts
@@ -9,6 +9,7 @@ import { uri } from "config";
 import { axiosWithIdToken } from "axios_config";
 
 jest.mock("react-redux");
+jest.mock("firebase_config");
 
 //参考記事: https://zenn.dev/bom_shibuya/articles/5c3ae7745c5e94
 

--- a/src/hooks/CodeAPIHooks/useFetchCodes.test.ts
+++ b/src/hooks/CodeAPIHooks/useFetchCodes.test.ts
@@ -1,0 +1,75 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { AxiosInstance } from "axios";
+import MockAdapter from "axios-mock-adapter";
+import { useSelector } from "react-redux";
+import { UserState } from "services/user/user";
+import { useFetchCodes } from "./useFetchCodes";
+
+import { uri } from "config";
+import { axiosWithIdToken } from "axios_config";
+
+jest.mock("react-redux");
+
+//参考記事: https://zenn.dev/bom_shibuya/articles/5c3ae7745c5e94
+
+const useSelectorMock = useSelector as jest.Mock<UserState>;
+
+// jest mockの第一引数にモジュールを入れることでモジュールをmockできます
+
+describe("useFetchCodes", () => {
+  beforeEach(() => {
+    // selectorのレスポンスを設定する
+    useSelectorMock.mockReturnValue({
+      user: {
+        id: "few",
+        displayName: "ffawefae",
+        email: "feaeafa@fafe.com",
+        picture: "fewfawefaewf.png",
+        jwt: "feefawef390urjfo",
+      },
+      isLogin: false,
+      unRegisterObserver: null,
+    });
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("正常系のテスト", async () => {
+    const mock = new MockAdapter(axiosWithIdToken as AxiosInstance);
+    const mockResponseDeta = [
+      {
+        id: "123",
+        codeContent: "print('hello')",
+        language: "python",
+        updatedAt: "20220303",
+        createdAt: "20220303",
+        user: "teru",
+        step: "1",
+      },
+    ];
+    const url = `${uri}/codes`;
+    mock.onGet(url).reply(200, mockResponseDeta); // モックAPIを定義
+
+    //実行
+    const { result, waitForNextUpdate } = renderHook(() => useFetchCodes());
+    expect(result.current.data).toEqual(undefined);
+
+    expect(result.current.error).toEqual(undefined);
+    expect(result.current.loading).toEqual(true);
+    await waitForNextUpdate();
+    expect(result.current.data).toEqual([
+      {
+        id: "123",
+        codeContent: "print('hello')",
+        language: "python",
+        updatedAt: "20220303",
+        createdAt: "20220303",
+        user: "teru",
+        step: "1",
+      },
+    ]);
+    expect(result.current.error).toEqual(undefined);
+    expect(result.current.loading).toEqual(false);
+  });
+});

--- a/src/hooks/CodeAPIHooks/useFetchCodes.ts
+++ b/src/hooks/CodeAPIHooks/useFetchCodes.ts
@@ -1,0 +1,59 @@
+import { AxiosError, AxiosResponse } from "axios";
+import { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import { RootState } from "store";
+import { axiosWithIdToken } from "axios_config";
+
+export type IState = {
+  data?: CodeType[];
+  error?: AxiosError;
+  loading: boolean;
+};
+
+export type IResponse = IState & {
+  update: (userId: string, stepID?: string) => void;
+};
+
+export type CodeType = {
+  id: string;
+  codeContent: string;
+  language: string;
+  updatedAt: string;
+  createdAt: string;
+  user: string;
+  step: string;
+};
+
+export const useFetchCodes = (): IResponse => {
+  const { user } = useSelector((state: RootState) => state.user);
+  const [res, setRes] = useState<IState>({
+    loading: false,
+  });
+  useEffect(() => {
+    if (user) {
+      fetchRequest(user.id);
+    }
+  }, []);
+
+  const fetchRequest = (userID: string, stepID?: string) => {
+    setRes((prevState) => ({ ...prevState, loading: true }));
+    axiosWithIdToken
+      .get("/codes", {
+        params: {
+          user: userID,
+          step: stepID,
+        },
+      })
+      .then((response: AxiosResponse<CodeType[]>) => {
+        setRes({ data: response.data, loading: false });
+      })
+      .catch((error: AxiosError) => {
+        setRes({ error, loading: false });
+      });
+  };
+
+  return {
+    ...res,
+    update: fetchRequest,
+  };
+};

--- a/src/hooks/CodeAPIHooks/useRunCodes.test.ts
+++ b/src/hooks/CodeAPIHooks/useRunCodes.test.ts
@@ -6,6 +6,8 @@ import { uri } from "config";
 import { useRunCodes } from "./useRunCodes";
 import { axiosWithIdToken } from "axios_config";
 
+jest.mock("firebase_config");
+
 describe("useRunCodes", () => {
   afterEach(() => {
     jest.resetAllMocks();

--- a/src/hooks/CodeAPIHooks/useRunCodes.test.ts
+++ b/src/hooks/CodeAPIHooks/useRunCodes.test.ts
@@ -1,0 +1,50 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import { AxiosInstance } from "axios";
+import MockAdapter from "axios-mock-adapter";
+
+import { uri } from "config";
+import { useRunCodes } from "./useRunCodes";
+import { axiosWithIdToken } from "axios_config";
+
+describe("useRunCodes", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("正常系のテスト", async () => {
+    const mock = new MockAdapter(axiosWithIdToken as AxiosInstance);
+    const mockResponseDeta = [
+      {
+        unityUrl: "https://test.com/",
+        jsonId: "resultJsonId",
+      },
+    ];
+    const url = `${uri}/codes/codeId1/run/`;
+    mock.onGet(url).reply(200, mockResponseDeta); // モックAPIを定義
+
+    //実行
+    const { result, waitForNextUpdate } = renderHook(() => useRunCodes());
+    const runCodes = result.current.runCodes;
+
+    act(() => {
+      runCodes("codeId1", "codeId2", "codeId3");
+    });
+
+    await waitForNextUpdate();
+
+    expect(result.current.data).toEqual([
+      {
+        unityUrl: "https://test.com/",
+        jsonId: "resultJsonId",
+      },
+    ]);
+    expect(result.current.error).toEqual(undefined);
+    expect(result.current.loading).toEqual(false);
+
+    expect(mock.history["get"][0].url).toEqual("/codes/codeId1/run/");
+    expect(mock.history["get"][0].params).toEqual({
+      p1: "codeId2",
+      p2: "codeId3",
+    });
+  });
+});

--- a/src/hooks/CodeAPIHooks/useRunCodes.ts
+++ b/src/hooks/CodeAPIHooks/useRunCodes.ts
@@ -1,0 +1,51 @@
+import { AxiosError, AxiosResponse } from "axios";
+import { axiosWithIdToken } from "axios_config";
+import { useState } from "react";
+
+export type IState = {
+  data?: SimulationResult;
+  error?: any;
+  loading: boolean;
+};
+
+export type IResponse = IState & {
+  runCodes: (...codeIds: string[]) => void;
+};
+
+export type SimulationResult = {
+  unityUrl: string;
+  jsonId: string;
+};
+
+export const useRunCodes = (): IResponse => {
+  const [res, setRes] = useState<IState>({
+    loading: false,
+  });
+
+  const _runCodes = (...codeIds: string[]) => {
+    if (codeIds.length == 0) return;
+
+    setRes((prevState) => ({ ...prevState, loading: true }));
+
+    const params: { [key: string]: any } = {};
+    for (let i = 1; i < codeIds.length; i++) {
+      params[`p${i}`] = codeIds[i];
+    }
+
+    axiosWithIdToken
+      .get(`/codes/${codeIds[0]}/run/`, {
+        params: params,
+      })
+      .then((response: AxiosResponse<any>) => {
+        setRes({ data: response.data, loading: false });
+      })
+      .catch((error: AxiosError) => {
+        setRes({ error: error, loading: false });
+      });
+  };
+
+  return {
+    ...res,
+    runCodes: _runCodes,
+  };
+};

--- a/src/hooks/ResultAPIHooks/useFetchResult.test.ts
+++ b/src/hooks/ResultAPIHooks/useFetchResult.test.ts
@@ -6,6 +6,8 @@ import { uri } from "config";
 import { useFetchResult } from "./useFetchResult";
 import { AxiosInstance } from "axios";
 
+jest.mock("firebase_config");
+
 describe("useFetchResult", () => {
   afterEach(() => {
     jest.resetAllMocks();

--- a/src/hooks/ResultAPIHooks/useFetchResult.test.ts
+++ b/src/hooks/ResultAPIHooks/useFetchResult.test.ts
@@ -1,0 +1,50 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import { axiosWithIdToken } from "axios_config";
+import MockAdapter from "axios-mock-adapter";
+
+import { uri } from "config";
+import { useFetchResult } from "./useFetchResult";
+import { AxiosInstance } from "axios";
+
+describe("useFetchResult", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("正常系のテスト", async () => {
+    const mock = new MockAdapter(axiosWithIdToken as AxiosInstance);
+    const mockResponseDeta = [
+      {
+        id: "resultId",
+        jsonPath: "/tmp/jsonPath",
+        step: 15,
+        codes: ["codeId1", "codeId2", "codeId3"],
+      },
+    ];
+    const url = `${uri}/results/resultId/`;
+    mock.onGet(url).reply(200, mockResponseDeta); // モックAPIを定義
+
+    //実行
+    const { result, waitForNextUpdate } = renderHook(() => useFetchResult());
+    const fetchResult = result.current.fetchResult;
+
+    act(() => {
+      fetchResult("resultId");
+    });
+
+    await waitForNextUpdate();
+
+    expect(result.current.data).toEqual([
+      {
+        id: "resultId",
+        jsonPath: "/tmp/jsonPath",
+        step: 15,
+        codes: ["codeId1", "codeId2", "codeId3"],
+      },
+    ]);
+    expect(result.current.error).toEqual(undefined);
+    expect(result.current.loading).toEqual(false);
+
+    expect(mock.history["get"][0].url).toEqual("/results/resultId/");
+  });
+});

--- a/src/hooks/ResultAPIHooks/useFetchResult.ts
+++ b/src/hooks/ResultAPIHooks/useFetchResult.ts
@@ -1,0 +1,43 @@
+import { AxiosError, AxiosResponse } from "axios";
+import { useState } from "react";
+import { axiosWithIdToken } from "axios_config";
+
+export type IState = {
+  data?: ResultType;
+  error?: AxiosError;
+  loading: boolean;
+};
+
+export type IResponse = IState & {
+  fetchResult: (resultId: string) => Promise<void>;
+};
+
+export type ResultType = {
+  id: string;
+  jsonPath: string;
+  step: number;
+  codes: string[];
+};
+
+export const useFetchResult = (): IResponse => {
+  const [res, setRes] = useState<IState>({
+    loading: false,
+  });
+
+  const _fetchResult = async (resultId: string) => {
+    setRes((prevState) => ({ ...prevState, loading: true }));
+    await axiosWithIdToken
+      .get(`/results/${resultId}/`)
+      .then((response: AxiosResponse<ResultType>) => {
+        setRes({ data: response.data, loading: false });
+      })
+      .catch((error: AxiosError) => {
+        setRes({ error, loading: false });
+      });
+  };
+
+  return {
+    ...res,
+    fetchResult: _fetchResult,
+  };
+};

--- a/src/hooks/RoomSyncHooks/useRoomSync.test.ts
+++ b/src/hooks/RoomSyncHooks/useRoomSync.test.ts
@@ -60,7 +60,7 @@ const actions: { [id: string]: UserAction } = {
 const initialRoomInfo: RoomInfo = {
   name: "room's name",
   host: "userid1",
-  state: "waiting",
+  status: "waiting",
 };
 
 const initialRoomState: RoomState = {

--- a/src/hooks/RoomSyncHooks/useRoomSync.test.ts
+++ b/src/hooks/RoomSyncHooks/useRoomSync.test.ts
@@ -31,14 +31,17 @@ const users: { [id: string]: UserState } = {
   userid1: {
     displayName: "user1",
     ready: true,
+    status: "waiting",
   },
   userid2: {
     displayName: "user2",
     ready: false,
+    status: "watching",
   },
   userid3: {
     displayName: "user3",
     ready: true,
+    status: "disconnect",
   },
 };
 
@@ -125,12 +128,9 @@ describe("Test Cases for functions in useRoomSync", () => {
       expect(
         isHost(
           {
-            ...initialRoomState,
-            info: {
-              ...initialRoomInfo,
-              host: "hostUserId",
-            },
-          } as RoomState,
+            ...initialRoomInfo,
+            host: "hostUserId",
+          } as RoomInfo,
           {
             ...userState.user,
             id: "hostUserId",
@@ -143,12 +143,9 @@ describe("Test Cases for functions in useRoomSync", () => {
       expect(
         isHost(
           {
-            ...initialRoomState,
-            info: {
-              ...initialRoomInfo,
-              host: "hostUserId",
-            },
-          } as RoomState,
+            ...initialRoomInfo,
+            host: "hostUserId",
+          } as RoomInfo,
           {
             ...userState.user,
             id: "notHostUserId",
@@ -159,16 +156,10 @@ describe("Test Cases for functions in useRoomSync", () => {
 
     it("異常系（room.infoがない場合）", () => {
       expect(
-        isHost(
-          {
-            ...initialRoomState,
-            info: undefined,
-          } as RoomState,
-          {
-            ...userState.user,
-            id: "hostUserId",
-          } as User
-        )
+        isHost(undefined, {
+          ...userState.user,
+          id: "hostUserId",
+        } as User)
       ).toBeFalsy();
     });
 
@@ -176,12 +167,9 @@ describe("Test Cases for functions in useRoomSync", () => {
       expect(
         isHost(
           {
-            ...initialRoomState,
-            info: {
-              ...initialRoomInfo,
-              host: "hostUserId",
-            },
-          } as RoomState,
+            ...initialRoomInfo,
+            host: "hostUserId",
+          } as RoomInfo,
           undefined
         )
       ).toBeFalsy();

--- a/src/hooks/RoomSyncHooks/useRoomSync.ts
+++ b/src/hooks/RoomSyncHooks/useRoomSync.ts
@@ -2,13 +2,13 @@ import { useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import {
-  RoomState,
   UserStateUpdate,
   UserAction,
   UserActionUpdate,
   ThunkResult,
   RoomInfo,
   exitRoom,
+  RoomInfoUpdate,
 } from "services/RoomSync/RoomSync";
 import {
   addActionAsync,
@@ -23,12 +23,14 @@ import {
   updateRoomAsync,
 } from "services/RoomSync/DBOperator/DBOperator";
 import {
+  cancelUserStateOnDisconnect,
   startActionsDBSync,
   startMembersDBSync,
   startRoomDBSync,
   stopActionsDBSync,
   stopMembersDBSync,
   stopRoomDBSync,
+  updateUserStateOnDisconnect,
 } from "services/RoomSync/DBListener/DBListener";
 import { User } from "services/user/user";
 import { RootState } from "store";
@@ -39,46 +41,86 @@ export const useRoomSync = () => {
   const dispatch = useDispatch();
 
   return {
+    /**
+     * ルーム情報
+     */
     room: room,
-    isHost: useMemo(() => isHost(room, user), [room, user]),
+    /**
+     * ログインユーザがルームのホストかどうか
+     */
+    isHost: useMemo(() => isHost(room.info, user), [room.info, user]),
+    /**
+     * ログインユーザをホストとしてルームを作成する
+     */
     createRoom: () => {
       if (user) dispatch(createRoomAsync("blank", user));
     },
+    /**
+     * ルームを検索して可能であればルームに入室する
+     * @param roomId ルームID
+     */
     enterRoom: (roomId: string) => {
       if (user) dispatch(enterRoomAsync(roomId, user));
     },
+    /**
+     * 入室中のルームから退室する
+     */
     exitRoom: () => {
       if (room.id && user) {
-        if (isHost(room, user)) {
+        if (isHost(room.info, user)) {
           dispatch(exitRoomAsHostAsync(user.id));
         } else {
           dispatch(exitRoomAsync(user.id));
         }
       }
     },
-    updateMember: (data: UserStateUpdate) => {
-      if (room.id && user) updateMemberAsync(room.id, user.id, data);
+    /**
+     * 入室中のルーム情報を更新する
+     * @param data ルーム情報
+     */
+    updateRoomInfo: async (data: RoomInfoUpdate) => {
+      if (room.id) await updateRoomAsync(room.id, data);
     },
-    addAction: (data: UserAction) => {
-      if (room.id) addActionAsync(room.id, data);
+    /**
+     * 入室中のルームでのユーザ情報を更新する
+     * @param data ユーザ情報
+     */
+    updateMember: async (data: UserStateUpdate) => {
+      if (room.id && user) await updateMemberAsync(room.id, user.id, data);
     },
-    updateAction: (id: string, data: UserActionUpdate) => {
-      if (room.id) updateActionAsync(room.id, id, data);
+    /**
+     * 入室中のルームでアクションを起こす
+     * @param data アクション情報
+     */
+    addAction: async (data: UserAction) => {
+      if (room.id) await addActionAsync(room.id, data);
     },
-    removeAction: (id: string) => {
-      if (room.id) removeActionAsync(room.id, id);
+    /**
+     * 入室中のルームで起こしたアクション情報を更新する
+     * @param id アクションID
+     * @param data アクション情報
+     */
+    updateAction: async (id: string, data: UserActionUpdate) => {
+      if (room.id) await updateActionAsync(room.id, id, data);
+    },
+    /**
+     * 入室中のルームで起こしたアクションを取り消す
+     * @param id アクションID
+     */
+    removeAction: async (id: string) => {
+      if (room.id) await removeActionAsync(room.id, id);
     },
   };
 };
 
 /**
  * ユーザがホストか判定
- * @param room ルーム
+ * @param roomInfo ルーム情報
  * @param user ユーザ
  * @returns true: ホストである，false: ホストでない
  */
-export const isHost = (room: RoomState, user?: User | null) => {
-  return room.info && user && room.info.host == user.id ? true : false;
+export const isHost = (roomInfo?: RoomInfo, user?: User | null) => {
+  return roomInfo && user && roomInfo.host == user.id ? true : false;
 };
 
 /**
@@ -92,7 +134,7 @@ export const createRoomAsync = (roomName: string, user: User): ThunkResult => {
     const roomInfo: RoomInfo = {
       name: roomName,
       host: user.id,
-      state: "waiting",
+      status: "waiting",
     };
     const dbRef = await pushRoomAsync(roomInfo);
     const key = dbRef.key;
@@ -103,7 +145,7 @@ export const createRoomAsync = (roomName: string, user: User): ThunkResult => {
 };
 
 /**
- * ルームに入る
+ * ルームに入れるか確認してからルームに入る
  * @param roomId ルームID
  * @param user ルームに入るユーザ
  * @returns dispatch用関数
@@ -112,16 +154,23 @@ export const enterRoomAsync = (roomId: string, user: User): ThunkResult => {
   return async (dispatch: any) => {
     if (roomId == "") return;
     const data = await getRoomAsync(roomId);
-    //部屋が存在したら入室処理
+    //ルームが存在したら入室処理
     if (data) {
       dispatch(_enterRoomAsync(roomId, user));
     }
   };
 };
 
+/**
+ * ルームに入る
+ * @param roomId ルームID
+ * @param user ユーザ情報
+ * @returns dispatch用関数
+ */
 const _enterRoomAsync = (roomId: string, user: User): ThunkResult => {
   return async (dispatch: any) => {
-    initMemberAsync(roomId, user);
+    await initMemberAsync(roomId, user);
+    await updateUserStateOnDisconnect(roomId, user.id, {status: "disconnect"});
     dispatch(startRoomDBSync(roomId));
     dispatch(startMembersDBSync(roomId));
     dispatch(startActionsDBSync(roomId));
@@ -131,7 +180,6 @@ const _enterRoomAsync = (roomId: string, user: User): ThunkResult => {
 /**
  * ルームから退出する
  * ユーザがホストの場合は{@link exitRoomAsHostAsync}を使用
- * @param roomId ルームID
  * @param userId 退出するユーザID
  * @returns dispatch用関数
  */
@@ -139,6 +187,7 @@ export const exitRoomAsync = (userId: string): ThunkResult => {
   return async (dispatch: any, getState: any) => {
     const roomId = getState().room.id;
     await removeMemberAsync(roomId, userId);
+    await cancelUserStateOnDisconnect(roomId, userId);
     dispatch(stopRoomDBSync());
     dispatch(stopMembersDBSync());
     dispatch(stopActionsDBSync());
@@ -148,7 +197,6 @@ export const exitRoomAsync = (userId: string): ThunkResult => {
 
 /**
  * 自分がホストでルームから退出する
- * @param roomId ルームID
  * @param userId 退出するユーザID（ホストID）
  * @param memberKeys メンバーIDリスト
  * @returns dispatch用関数

--- a/src/pages/CasualBattle/GameWatch/GameWatch.test.tsx
+++ b/src/pages/CasualBattle/GameWatch/GameWatch.test.tsx
@@ -1,11 +1,48 @@
 import React from "react";
 import { shallow } from "enzyme";
-import { CasualBattleGameWatch } from "./GameWatch";
 
-describe("<CasualBattleLobby />", () => {
-  it("auth snapshot test", () => {
+import { CasualBattleGameWatch } from "./GameWatch";
+import { IResponse, useGameWatchState } from "./hooks/useGameWatchState";
+
+jest.mock("./hooks/useGameWatchState");
+jest.mock("./hooks/useRunSimulation");
+
+const useGameWatchStateMock = useGameWatchState as jest.Mock;
+
+const state: IResponse = {
+  isAnalyzing: false,
+  analyzingError: false,
+  result: {
+    id: "resultId",
+    jsonPath: "/tmp/resultId",
+    step: 15,
+    codes: ["codeid1", "codeid2", "codeid3"],
+  },
+  exitBtnHandler: jest.fn(),
+};
+
+describe("<CasualBattleGameWatch />", () => {
+  beforeEach(() => {
+    useGameWatchStateMock.mockReturnValue({
+      ...state,
+    });
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("snapshot test", () => {
     const wrapper = shallow(<CasualBattleGameWatch />);
 
     expect(wrapper.getElements()).toMatchSnapshot();
+  });
+
+  it("exit button test", () => {
+    const wrapper = shallow(<CasualBattleGameWatch />);
+
+    const btn = wrapper.find("#exit-btn");
+    btn.simulate("click");
+
+    expect(state.exitBtnHandler).toHaveBeenCalled();
   });
 });

--- a/src/pages/CasualBattle/GameWatch/GameWatch.tsx
+++ b/src/pages/CasualBattle/GameWatch/GameWatch.tsx
@@ -1,17 +1,29 @@
 import React from "react";
 import { useGameWatchState } from "./hooks/useGameWatchState";
+import { useRunSimulation } from "./hooks/useRunSimulation";
 
 type Props = {};
 
 export const CasualBattleGameWatch: React.FC<Props> = () => {
-  const {isAnalysing, exitBtnHandler} = useGameWatchState();
+  useRunSimulation();
+  const { isAnalyzing, analyzingError, result, exitBtnHandler } =
+    useGameWatchState();
+
   return (
     <div>
       <div>結果</div>
       <div>
-        {isAnalysing ? "解析中" : "観戦中"}
+        ステータス：
+        {analyzingError
+          ? "シミュレーションエラー"
+          : isAnalyzing
+          ? "解析中"
+          : "観戦中"}
       </div>
-      <button onClick={exitBtnHandler}>退出</button>
+      {result ? <div>{JSON.stringify(result)}</div> : undefined}
+      <button id="exit-btn" onClick={exitBtnHandler}>
+        退出
+      </button>
     </div>
   );
 };

--- a/src/pages/CasualBattle/GameWatch/GameWatch.tsx
+++ b/src/pages/CasualBattle/GameWatch/GameWatch.tsx
@@ -1,16 +1,17 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { useGameWatchState } from "./hooks/useGameWatchState";
 
 type Props = {};
 
 export const CasualBattleGameWatch: React.FC<Props> = () => {
+  const {isAnalysing, exitBtnHandler} = useGameWatchState();
   return (
     <div>
       <div>結果</div>
-      <div>aaa</div>
       <div>
-        <Link to="/casual-battle/waiting-room">ロビーに戻る</Link>
+        {isAnalysing ? "解析中" : "観戦中"}
       </div>
+      <button onClick={exitBtnHandler}>退出</button>
     </div>
   );
 };

--- a/src/pages/CasualBattle/GameWatch/__snapshots__/GameWatch.test.tsx.snap
+++ b/src/pages/CasualBattle/GameWatch/__snapshots__/GameWatch.test.tsx.snap
@@ -1,21 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<CasualBattleLobby /> auth snapshot test 1`] = `
+exports[`<CasualBattleGameWatch /> snapshot test 1`] = `
 Array [
   <div>
     <div>
       結果
     </div>
     <div>
-      aaa
+      ステータス：
+      観戦中
     </div>
     <div>
-      <Link
-        to="/casual-battle/waiting-room"
-      >
-        ロビーに戻る
-      </Link>
+      {"id":"resultId","jsonPath":"/tmp/resultId","step":15,"codes":["codeid1","codeid2","codeid3"]}
     </div>
+    <button
+      id="exit-btn"
+      onClick={[MockFunction]}
+    >
+      退出
+    </button>
   </div>,
 ]
 `;

--- a/src/pages/CasualBattle/GameWatch/hooks/useGameWatchState.test.ts
+++ b/src/pages/CasualBattle/GameWatch/hooks/useGameWatchState.test.ts
@@ -1,0 +1,108 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import { useNavigate } from "react-router-dom";
+
+import { useGameWatchState } from "./useGameWatchState";
+import { useRoomSync } from "hooks/RoomSyncHooks/useRoomSync";
+import { RoomInfo, RoomState } from "services/RoomSync/RoomSync";
+import { IResponse, useFetchResult } from "hooks/ResultAPIHooks/useFetchResult";
+
+jest.mock("react-redux");
+jest.mock("react-router-dom");
+jest.mock("hooks/RoomSyncHooks/useRoomSync");
+jest.mock("hooks/ResultAPIHooks/useFetchResult");
+
+const useRoomSyncMock = useRoomSync as jest.Mock;
+const useNavigateMock = useNavigate as jest.Mock;
+const useFetchResultMock = useFetchResult as jest.Mock;
+
+const initialRoomInfo: RoomInfo = {
+  host: "hostId",
+  name: "roomName",
+  status: "watching",
+};
+
+const initialRoomState: RoomState = {
+  id: "roomId",
+  isEntered: true,
+  info: initialRoomInfo,
+  sortedKeysOfMembers: [],
+  members: {},
+  sortedKeysOfActions: [],
+  actions: {},
+};
+
+const initialRoomSyncState = {
+  room: { ...initialRoomState },
+  updateMember: jest.fn(),
+};
+
+const initialFetchResultState: IResponse = {
+  data: {
+    id: "resultId",
+    jsonPath: "/tmp/path",
+    step: 15,
+    codes: ["codeId1", "codeId2", "codeId3"],
+  },
+  fetchResult: jest.fn(),
+  loading: false,
+};
+
+const navigateMock = jest.fn();
+
+describe("useGameWatchState", () => {
+  beforeEach(() => {
+    useRoomSyncMock.mockReturnValue({ ...initialRoomSyncState });
+    useNavigateMock.mockReturnValue(navigateMock);
+    useFetchResultMock.mockReturnValue({ ...initialFetchResultState });
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("render", () => {
+    const { result } = renderHook(() => useGameWatchState());
+    expect(result).toBeTruthy();
+    expect(initialRoomSyncState.updateMember).lastCalledWith({
+      status: "watching",
+    });
+  });
+
+  it("room.isEntered=falseでページ遷移", () => {
+    useRoomSyncMock.mockReturnValue({
+      ...initialRoomSyncState,
+      room: {
+        ...initialRoomState,
+        isEntered: false,
+      },
+    });
+    renderHook(() => useGameWatchState());
+    expect(navigateMock).lastCalledWith("/casual-battle");
+  });
+
+  it("シミュレーション結果のフェッチ", () => {
+    useRoomSyncMock.mockReturnValue({
+      ...initialRoomSyncState,
+      room: {
+        ...initialRoomState,
+        info: {
+          ...initialRoomInfo,
+          analyzingResult: {
+            resultId: "resultId",
+          },
+        },
+      },
+    });
+    const { result } = renderHook(() => useGameWatchState());
+    expect(result.current.result).toEqual(initialFetchResultState.data);
+    expect(initialFetchResultState.fetchResult).lastCalledWith("resultId");
+  });
+
+  it("exec exitBtnHandler", () => {
+    const { result } = renderHook(() => useGameWatchState());
+    const { exitBtnHandler } = result.current;
+    act(() => {
+      exitBtnHandler();
+    });
+    expect(navigateMock).lastCalledWith("/casual-battle/waiting-room");
+  });
+});

--- a/src/pages/CasualBattle/GameWatch/hooks/useGameWatchState.ts
+++ b/src/pages/CasualBattle/GameWatch/hooks/useGameWatchState.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { useRoomSync } from "hooks/RoomSyncHooks/useRoomSync";
+
+export type IResponse = {
+  isAnalysing: boolean;
+  exitBtnHandler: () => void;
+};
+
+export const useGameWatchState = (): IResponse => {
+  const { room, updateMember } = useRoomSync();
+  const navigate = useNavigate();
+
+  //初期処理
+  useEffect(() => {
+    //ユーザ状態を更新
+    updateMember({
+      status: "watching",
+    });
+    //シミュレーションの実行
+  }, []);
+
+  useEffect(() => {
+    if(room.info?.analyzingResult) {
+      console.log("解析終了！");
+    }
+  }, [room.info?.analyzingResult]);
+
+  const _exitBtnHandler = () => {
+    navigate("/casual-battle/waiting-room");
+  };
+
+  return {
+    isAnalysing: room.info?.analyzingResult == undefined,
+    exitBtnHandler: _exitBtnHandler,
+  };
+};

--- a/src/pages/CasualBattle/GameWatch/hooks/useRunSimulation.test.ts
+++ b/src/pages/CasualBattle/GameWatch/hooks/useRunSimulation.test.ts
@@ -1,0 +1,133 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { useNavigate } from "react-router-dom";
+
+import { useRunSimulation } from "./useRunSimulation";
+import { useRoomSync } from "hooks/RoomSyncHooks/useRoomSync";
+import { RoomInfo, RoomState, UserState } from "services/RoomSync/RoomSync";
+import { IResponse, useRunCodes } from "hooks/CodeAPIHooks/useRunCodes";
+
+jest.mock("react-redux");
+jest.mock("react-router-dom");
+jest.mock("hooks/RoomSyncHooks/useRoomSync");
+jest.mock("hooks/CodeAPIHooks/useRunCodes");
+
+const useRoomSyncMock = useRoomSync as jest.Mock;
+const useNavigateMock = useNavigate as jest.Mock;
+const useRunCodesMock = useRunCodes as jest.Mock;
+
+const users: { [id: string]: UserState } = {
+  userid1: {
+    displayName: "user1",
+    ready: true,
+    status: "waiting",
+    codeId: "codeid1",
+  },
+  userid2: {
+    displayName: "user2",
+    ready: false,
+    status: "watching",
+    codeId: "codeid2",
+  },
+  userid3: {
+    displayName: "user3",
+    ready: true,
+    status: "disconnect",
+    codeId: "codeid3",
+  },
+};
+
+const initialRoomInfo: RoomInfo = {
+  host: "userid1",
+  name: "roomName",
+  status: "watching",
+};
+
+const initialRoomState: RoomState = {
+  id: "roomId",
+  isEntered: true,
+  info: initialRoomInfo,
+  sortedKeysOfMembers: ["userid3", "userid2", "userid1"],
+  members: {
+    userid1: users["userid1"],
+    userid2: users["userid2"],
+    userid3: users["userid3"],
+  },
+  sortedKeysOfActions: [],
+  actions: {},
+};
+
+const initialRoomSyncState = {
+  room: { ...initialRoomState },
+  isHost: true,
+  updateRoomInfo: jest.fn(),
+};
+
+const initialRunCodesState: IResponse = {
+  data: {
+    unityUrl: "https://test.com/",
+    jsonId: "jsonId",
+  },
+  runCodes: jest.fn(),
+  loading: false,
+};
+
+const navigateMock = jest.fn();
+
+describe("useRunSimulation", () => {
+  beforeEach(() => {
+    useRoomSyncMock.mockReturnValue({ ...initialRoomSyncState });
+    useNavigateMock.mockReturnValue(navigateMock);
+    useRunCodesMock.mockReturnValue({ ...initialRunCodesState });
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("render", () => {
+    const { result } = renderHook(() => useRunSimulation());
+    expect(result.current).toBeTruthy();
+    expect(initialRunCodesState.runCodes).lastCalledWith(
+      "codeid3",
+      "codeid2",
+      "codeid1"
+    );
+  });
+
+  it("ホストでない場合シミュレーションが実行されない", () => {
+    useRoomSyncMock.mockReturnValue({
+      ...initialRoomSyncState,
+      isHost: false,
+    });
+    renderHook(() => useRunSimulation());
+    expect(initialRunCodesState.runCodes).not.toHaveBeenCalled();
+  });
+
+  it("シミュレーション結果が更新されたらDB上のルーム情報を更新", () => {
+    useRunCodesMock.mockReturnValue({
+      ...initialRunCodesState,
+      data: {
+        jsonId: "jsonId",
+        unityUrl: "https://test.com/",
+      },
+    });
+    renderHook(() => useRunSimulation());
+    expect(initialRoomSyncState.updateRoomInfo).lastCalledWith({
+      analyzingResult: {
+        resultId: "jsonId",
+      },
+    });
+  });
+
+  it("シミュレーションでエラーが発生した場合はDB上のルーム情報を更新", () => {
+    useRunCodesMock.mockReturnValue({
+      ...initialRunCodesState,
+      error: "エラー",
+    });
+    renderHook(() => useRunSimulation());
+    expect(initialRoomSyncState.updateRoomInfo).lastCalledWith({
+      analyzingResult: {
+        error: "シミュレーション実行中にエラーが発生しました。",
+      },
+    });
+  });
+});

--- a/src/pages/CasualBattle/GameWatch/hooks/useRunSimulation.ts
+++ b/src/pages/CasualBattle/GameWatch/hooks/useRunSimulation.ts
@@ -1,0 +1,52 @@
+import { useEffect } from "react";
+
+import { useRoomSync } from "hooks/RoomSyncHooks/useRoomSync";
+import { useRunCodes } from "hooks/CodeAPIHooks/useRunCodes";
+
+export type IResponse = {};
+
+export const useRunSimulation = (): IResponse => {
+  const { room, isHost, updateRoomInfo } = useRoomSync();
+  const {
+    data: simulationResult,
+    error: simulationError,
+    runCodes,
+  } = useRunCodes();
+
+  //初期処理
+  useEffect(() => {
+    //シミュレーションの実行(ホストのみ実行)
+    if (isHost) {
+      const codes: string[] = [];
+      room.sortedKeysOfMembers.forEach((key) => {
+        const member = room.members[key];
+        if (member.codeId) codes.push(member.codeId);
+      });
+      runCodes(...codes);
+    }
+  }, []);
+
+  //シミュレーション結果を受信した場合
+  useEffect(() => {
+    if (simulationResult) {
+      updateRoomInfo({
+        analyzingResult: {
+          resultId: simulationResult.jsonId,
+        },
+      });
+    }
+  }, [simulationResult]);
+
+  //シミュレーション中にエラーが発生した場合
+  useEffect(() => {
+    if (simulationError) {
+      updateRoomInfo({
+        analyzingResult: {
+          error: "シミュレーション実行中にエラーが発生しました。",
+        },
+      });
+    }
+  }, [simulationError]);
+
+  return {};
+};

--- a/src/pages/CasualBattle/Lobby/Lobby.test.tsx
+++ b/src/pages/CasualBattle/Lobby/Lobby.test.tsx
@@ -9,11 +9,12 @@ jest.mock("./hooks/useLobbyState");
 const useSelectorMock = useLobbyState as jest.Mock;
 
 const state: IResponse = {
+  roomCreateBtnDisabled: false,
   roomCreateBtnHandler: jest.fn(),
   roomSearchBtnHandler: jest.fn(),
 };
 
-describe("<CasualBattleWaitingRoom />", () => {
+describe("<CasualBattleLobby />", () => {
   beforeEach(() => {
     useSelectorMock.mockReturnValue({
       ...state,
@@ -31,21 +32,19 @@ describe("<CasualBattleWaitingRoom />", () => {
 
   it("room create button test", () => {
     const wrapper = shallow(<CasualBattleLobby />);
-    const spy = jest.spyOn(state, "roomCreateBtnHandler");
 
     const btn = wrapper.find("#create-btn");
     btn.simulate("click");
 
-    expect(spy).toHaveBeenCalled();
+    expect(state.roomCreateBtnHandler).toHaveBeenCalled();
   });
 
   it("room search button test", () => {
     const wrapper = shallow(<CasualBattleLobby />);
-    const spy = jest.spyOn(state, "roomSearchBtnHandler");
 
     const btn = wrapper.find("#search-btn");
     btn.simulate("click");
 
-    expect(spy).toHaveBeenCalled();
+    expect(state.roomSearchBtnHandler).toHaveBeenCalled();
   });
 });

--- a/src/pages/CasualBattle/Lobby/Lobby.tsx
+++ b/src/pages/CasualBattle/Lobby/Lobby.tsx
@@ -4,12 +4,17 @@ import { useLobbyState } from "./hooks/useLobbyState";
 type Props = {};
 
 export const CasualBattleLobby: React.FC<Props> = () => {
-  const { roomCreateBtnHandler, roomSearchBtnHandler } = useLobbyState();
+  const { roomCreateBtnDisabled, roomCreateBtnHandler, roomSearchBtnHandler } =
+    useLobbyState();
 
   return (
     <div>
       <div>ルーム待機画面</div>
-      <button id="create-btn" onClick={roomCreateBtnHandler}>
+      <button
+        id="create-btn"
+        onClick={roomCreateBtnHandler}
+        disabled={roomCreateBtnDisabled}
+      >
         ルームを建てる
       </button>
       <button id="search-btn" onClick={roomSearchBtnHandler}>

--- a/src/pages/CasualBattle/Lobby/__snapshots__/Lobby.test.tsx.snap
+++ b/src/pages/CasualBattle/Lobby/__snapshots__/Lobby.test.tsx.snap
@@ -1,12 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<CasualBattleWaitingRoom /> snapshot test 1`] = `
+exports[`<CasualBattleLobby /> snapshot test 1`] = `
 Array [
   <div>
     <div>
       ルーム待機画面
     </div>
     <button
+      disabled={false}
       id="create-btn"
       onClick={[MockFunction]}
     >

--- a/src/pages/CasualBattle/Lobby/hooks/useLobbyState.test.ts
+++ b/src/pages/CasualBattle/Lobby/hooks/useLobbyState.test.ts
@@ -4,7 +4,6 @@ import { useNavigate } from "react-router-dom";
 import { useLobbyState } from "./useLobbyState";
 import { useRoomSync } from "hooks/RoomSyncHooks/useRoomSync";
 
-jest.mock("react-redux");
 jest.mock("react-router-dom");
 jest.mock("hooks/RoomSyncHooks/useRoomSync");
 
@@ -24,20 +23,21 @@ const initialRoomSyncState = {
   createRoom: jest.fn(),
 };
 
-const navigateMock = { do: jest.fn() };
+const navigateMock = jest.fn();
 
-describe("useWaitingRoomState", () => {
+describe("useLobbyState", () => {
   beforeEach(() => {
     useRoomSyncMock.mockReturnValue({ ...initialRoomSyncState });
-    useNavigateMock.mockReturnValue(navigateMock.do);
+    useNavigateMock.mockReturnValue(navigateMock);
+    initialRoomSyncState.createRoom.mockResolvedValue({});
   });
   afterEach(() => {
     jest.resetAllMocks();
   });
 
   it("render", () => {
-    const result = renderHook(() => useLobbyState());
-    expect(result).toBeTruthy();
+    const { result } = renderHook(() => useLobbyState());
+    expect(result.current).toBeTruthy();
   });
 
   it("room.isEntered=trueでページ遷移", () => {
@@ -48,29 +48,28 @@ describe("useWaitingRoomState", () => {
         isEntered: true,
       },
     });
-    const spyNavigate = jest.spyOn(navigateMock, "do");
     renderHook(() => useLobbyState());
-    expect(spyNavigate).lastCalledWith("/casual-battle/waiting-room");
+    expect(navigateMock).lastCalledWith("/casual-battle/waiting-room");
   });
 
   it("exec roomCreateBtnHandler", () => {
-    const spyCreateRoom = jest.spyOn(initialRoomSyncState, "createRoom");
     const { result } = renderHook(() => useLobbyState());
     const { roomCreateBtnHandler } = result.current;
+    expect(result.current.roomCreateBtnDisabled).toBe(false);
     act(() => {
       roomCreateBtnHandler();
     });
-    expect(spyCreateRoom).toBeCalledTimes(1);
+    expect(result.current.roomCreateBtnDisabled).toBe(true);
+    expect(initialRoomSyncState.createRoom).toBeCalledTimes(1);
   });
 
   it("exec roomSearchBtnHandler", () => {
-    const spyNavigate = jest.spyOn(navigateMock, "do");
     const { result } = renderHook(() => useLobbyState());
     const { roomSearchBtnHandler } = result.current;
     act(() => {
       roomSearchBtnHandler();
     });
-    expect(spyNavigate).toBeCalledTimes(1);
-    expect(spyNavigate).lastCalledWith("/casual-battle/search-room");
+    expect(navigateMock).toBeCalledTimes(1);
+    expect(navigateMock).lastCalledWith("/casual-battle/search-room");
   });
 });

--- a/src/pages/CasualBattle/Lobby/hooks/useLobbyState.ts
+++ b/src/pages/CasualBattle/Lobby/hooks/useLobbyState.ts
@@ -1,13 +1,15 @@
 import { useRoomSync } from "hooks/RoomSyncHooks/useRoomSync";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 export type IResponse = {
+  roomCreateBtnDisabled: boolean;
   roomCreateBtnHandler: () => void;
   roomSearchBtnHandler: () => void;
 };
 
 export const useLobbyState = (): IResponse => {
+  const [roomCreateBtnDisabled, setRoomCreateBtnDisabled] = useState(false);
   const { room, createRoom } = useRoomSync();
   const navigate = useNavigate();
 
@@ -18,7 +20,10 @@ export const useLobbyState = (): IResponse => {
   }, [room.isEntered]);
 
   const _roomCreateBtnHandler = () => {
-    createRoom();
+    setRoomCreateBtnDisabled(true);
+    createRoom().catch(() => {
+      setRoomCreateBtnDisabled(false);
+    });
   };
 
   const _roomSearchBtnHandler = () => {
@@ -26,6 +31,7 @@ export const useLobbyState = (): IResponse => {
   };
 
   return {
+    roomCreateBtnDisabled: roomCreateBtnDisabled,
     roomCreateBtnHandler: _roomCreateBtnHandler,
     roomSearchBtnHandler: _roomSearchBtnHandler,
   };

--- a/src/pages/CasualBattle/SearchRoom/SearchRoom.test.tsx
+++ b/src/pages/CasualBattle/SearchRoom/SearchRoom.test.tsx
@@ -9,12 +9,13 @@ jest.mock("./hooks/useSearchRoomState");
 const useSelectorMock = useSearchRoomState as jest.Mock;
 
 const state: IResponse = {
+  enterBtnDisabled: false,
   enterBtnClickHandler: jest.fn(),
   roomIdTextBoxChangeHandler: jest.fn(),
   roomIdTextBoxValue: "typed value",
 };
 
-describe("<CasualBattleWaitingRoom />", () => {
+describe("<CasualBattleSearchRoom />", () => {
   beforeEach(() => {
     useSelectorMock.mockReturnValue({
       ...state,
@@ -32,17 +33,15 @@ describe("<CasualBattleWaitingRoom />", () => {
 
   it("enter button test", () => {
     const wrapper = shallow(<CasualBattleSearchRoom />);
-    const spy = jest.spyOn(state, "enterBtnClickHandler");
 
     const btn = wrapper.find("#enter-btn");
     btn.simulate("click");
 
-    expect(spy).toHaveBeenCalled();
+    expect(state.enterBtnClickHandler).toHaveBeenCalled();
   });
 
   it("room id text box test", () => {
     const wrapper = shallow(<CasualBattleSearchRoom />);
-    const spy = jest.spyOn(state, "roomIdTextBoxChangeHandler");
 
     const event = {
       target: {
@@ -53,6 +52,6 @@ describe("<CasualBattleWaitingRoom />", () => {
     const btn = wrapper.find("#roomid-textbox");
     btn.simulate("change", event);
 
-    expect(spy).toHaveBeenCalled();
+    expect(state.roomIdTextBoxChangeHandler).toHaveBeenCalled();
   });
 });

--- a/src/pages/CasualBattle/SearchRoom/SearchRoom.tsx
+++ b/src/pages/CasualBattle/SearchRoom/SearchRoom.tsx
@@ -7,6 +7,7 @@ export const CasualBattleSearchRoom: React.FC<Props> = () => {
   const {
     roomIdTextBoxValue,
     roomIdTextBoxChangeHandler,
+    enterBtnDisabled,
     enterBtnClickHandler,
   } = useSearchRoomState();
 
@@ -18,7 +19,11 @@ export const CasualBattleSearchRoom: React.FC<Props> = () => {
         value={roomIdTextBoxValue}
         onChange={(e) => roomIdTextBoxChangeHandler(e.target.value)}
       ></input>
-      <button id="enter-btn" onClick={enterBtnClickHandler}>
+      <button
+        id="enter-btn"
+        onClick={enterBtnClickHandler}
+        disabled={enterBtnDisabled}
+      >
         ルームに入る
       </button>
     </div>

--- a/src/pages/CasualBattle/SearchRoom/__snapshots__/SearchRoom.test.tsx.snap
+++ b/src/pages/CasualBattle/SearchRoom/__snapshots__/SearchRoom.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<CasualBattleWaitingRoom /> snapshot test 1`] = `
+exports[`<CasualBattleSearchRoom /> snapshot test 1`] = `
 Array [
   <div>
     <div>
@@ -12,6 +12,7 @@ Array [
       value="typed value"
     />
     <button
+      disabled={false}
       id="enter-btn"
       onClick={[MockFunction]}
     >

--- a/src/pages/CasualBattle/SearchRoom/hooks/useSearchRoomState.test.ts
+++ b/src/pages/CasualBattle/SearchRoom/hooks/useSearchRoomState.test.ts
@@ -4,7 +4,6 @@ import { useNavigate } from "react-router-dom";
 import { useSearchRoomState } from "./useSearchRoomState";
 import { useRoomSync } from "hooks/RoomSyncHooks/useRoomSync";
 
-jest.mock("react-redux");
 jest.mock("react-router-dom");
 jest.mock("hooks/RoomSyncHooks/useRoomSync");
 
@@ -24,12 +23,13 @@ const initialRoomSyncState = {
   enterRoom: jest.fn(),
 };
 
-const navigateMock = { do: jest.fn() };
+const navigateMock = jest.fn();
 
 describe("useWaitingRoomState", () => {
   beforeEach(() => {
     useRoomSyncMock.mockReturnValue({ ...initialRoomSyncState });
-    useNavigateMock.mockReturnValue(navigateMock.do);
+    useNavigateMock.mockReturnValue(navigateMock);
+    initialRoomSyncState.enterRoom.mockResolvedValue({});
   });
   afterEach(() => {
     jest.resetAllMocks();
@@ -37,6 +37,7 @@ describe("useWaitingRoomState", () => {
 
   it("render", () => {
     const { result } = renderHook(() => useSearchRoomState());
+    expect(result.current).toBeTruthy();
     expect(result.current.roomIdTextBoxValue).toBe("");
   });
 
@@ -48,9 +49,8 @@ describe("useWaitingRoomState", () => {
         isEntered: true,
       },
     });
-    const spyNavigate = jest.spyOn(navigateMock, "do");
     renderHook(() => useSearchRoomState());
-    expect(spyNavigate).lastCalledWith("/casual-battle/waiting-room");
+    expect(navigateMock).lastCalledWith("/casual-battle/waiting-room");
   });
 
   it("exec roomIdTextBoxChangeHandler", () => {
@@ -63,7 +63,6 @@ describe("useWaitingRoomState", () => {
   });
 
   it("exec enterBtnClickHandler", () => {
-    const spyEnterRoom = jest.spyOn(initialRoomSyncState, "enterRoom");
     const { result } = renderHook(() => useSearchRoomState());
     const { roomIdTextBoxChangeHandler } = result.current;
 
@@ -72,10 +71,11 @@ describe("useWaitingRoomState", () => {
     });
 
     const { enterBtnClickHandler } = result.current;
+    expect(result.current.enterBtnDisabled).toBe(false);
     act(() => {
       enterBtnClickHandler();
     });
-
-    expect(spyEnterRoom).lastCalledWith("roomid");
+    expect(result.current.enterBtnDisabled).toBe(true);
+    expect(initialRoomSyncState.enterRoom).lastCalledWith("roomid");
   });
 });

--- a/src/pages/CasualBattle/SearchRoom/hooks/useSearchRoomState.ts
+++ b/src/pages/CasualBattle/SearchRoom/hooks/useSearchRoomState.ts
@@ -1,16 +1,19 @@
-import { useRoomSync } from "hooks/RoomSyncHooks/useRoomSync";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { useRoomSync } from "hooks/RoomSyncHooks/useRoomSync";
+
 export type IResponse = {
   roomIdTextBoxValue: string;
-  roomIdTextBoxChangeHandler: any; // (value: string) => void;にしたいけど，no-unused-varsにひっかかる．
+  roomIdTextBoxChangeHandler: (value: string) => void;
+  enterBtnDisabled: boolean;
   enterBtnClickHandler: () => void;
 };
 
 export const useSearchRoomState = (): IResponse => {
   const { room, enterRoom } = useRoomSync();
   const [roomId, setRoomId] = useState("");
+  const [enterBtnDisabled, setEnterBtnDisabled] = useState(false);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -24,12 +27,16 @@ export const useSearchRoomState = (): IResponse => {
   };
 
   const _enterBtnHandler = () => {
-    enterRoom(roomId);
+    setEnterBtnDisabled(true);
+    enterRoom(roomId).catch(() => {
+      setEnterBtnDisabled(false);
+    });
   };
 
   return {
     roomIdTextBoxValue: roomId,
     roomIdTextBoxChangeHandler: _roomIdTextBoxChangeHandler,
+    enterBtnDisabled: enterBtnDisabled,
     enterBtnClickHandler: _enterBtnHandler,
   };
 };

--- a/src/pages/CasualBattle/WaitingRoom/WaitingRoom.test.tsx
+++ b/src/pages/CasualBattle/WaitingRoom/WaitingRoom.test.tsx
@@ -14,20 +14,28 @@ const state: IResponse = {
     host: {
       displayName: "host user",
       ready: false,
+      status: "waiting",
+      codeId: "hostCodeId",
     },
     memberKeys: ["host user id", "user id 1", "user id 2"],
     members: {
       "host user id": {
         displayName: "host user",
         ready: false,
+        status: "waiting",
+        codeId: "hostCodeId1",
       },
       "user id 1": {
         displayName: "user 1",
         ready: true,
+        status: "watching",
+        codeId: "codeId1",
       },
       "user id 2": {
         displayName: "user 2",
         ready: true,
+        status: "disconnect",
+        codeId: "codeId2",
       },
     },
     actionKeys: ["action id 1", "action id 2", "action id 3"],
@@ -47,10 +55,39 @@ const state: IResponse = {
     },
   },
   isHost: true,
+  status: "waiting",
+  ready: true,
   readyBtnHandler: jest.fn(),
+  readyBtnDisabled: false,
   exitBtnHandler: jest.fn(),
   startBtnDisabled: false,
   startBtnHandler: jest.fn(),
+
+  code: {
+    codes: [
+      {
+        id: "hostCodeId1",
+        codeContent: "print('hello world)'",
+        createdAt: "2022-02-16T05:05:46.315585+09:00",
+        updatedAt: "2022-02-16T06:33:00.058575+09:00",
+        language: "1",
+        step: "3",
+        user: "host user id",
+      },
+      {
+        id: "hostCodeId2",
+        codeContent: "alert('hello world)'",
+        createdAt: "2022-02-16T10:00:46.315585+09:00",
+        updatedAt: "2022-02-16T11:10:00.058575+09:00",
+        language: "1",
+        step: "3",
+        user: "host user id",
+      },
+    ],
+    loading: false,
+  },
+  selectedCodeId: "codeId1",
+  onChangeSelectedCodeId: jest.fn(),
 };
 
 describe("<CasualBattleWaitingRoom />", () => {
@@ -71,31 +108,40 @@ describe("<CasualBattleWaitingRoom />", () => {
 
   it("start button test", () => {
     const wrapper = shallow(<CasualBattleWaitingRoom />);
-    const spy = jest.spyOn(state, "startBtnHandler");
 
     const btn = wrapper.find("#start-btn");
     btn.simulate("click");
 
-    expect(spy).toHaveBeenCalled();
+    expect(state.startBtnHandler).toHaveBeenCalled();
   });
 
   it("exit button test", () => {
     const wrapper = shallow(<CasualBattleWaitingRoom />);
-    const spy = jest.spyOn(state, "exitBtnHandler");
 
     const btn = wrapper.find("#exit-btn");
     btn.simulate("click");
 
-    expect(spy).toHaveBeenCalled();
+    expect(state.exitBtnHandler).toHaveBeenCalled();
   });
 
   it("ready button test", () => {
     const wrapper = shallow(<CasualBattleWaitingRoom />);
-    const spy = jest.spyOn(state, "readyBtnHandler");
 
     const btn = wrapper.find("#ready-btn");
     btn.simulate("click");
 
-    expect(spy).toHaveBeenCalled();
+    expect(state.readyBtnHandler).toHaveBeenCalled();
+  });
+
+  it("inputが変化した時にonChangeSelectedCodeIdが呼ばれるか", () => {
+    const wrapper = shallow(<CasualBattleWaitingRoom />);
+
+    wrapper.find("input[value='hostCodeId1']").simulate("change", {
+      target: {
+        value: "selectedCodeId",
+      },
+    });
+    expect(state.onChangeSelectedCodeId).toBeCalledTimes(1);
+    expect(state.onChangeSelectedCodeId).lastCalledWith("selectedCodeId");
   });
 });

--- a/src/pages/CasualBattle/WaitingRoom/WaitingRoom.tsx
+++ b/src/pages/CasualBattle/WaitingRoom/WaitingRoom.tsx
@@ -8,17 +8,21 @@ export const CasualBattleWaitingRoom: React.FC<Props> = () => {
     roomInfo,
     isHost,
     status,
+    ready,
     readyBtnHandler,
+    readyBtnDisabled,
     exitBtnHandler,
     startBtnDisabled,
     startBtnHandler,
+    code,
+    selectedCodeId,
+    onChangeSelectedCodeId,
   } = useWaitingRoomState();
 
   return (
     <div>
       <div>ルーム待機画面</div>
       <div>
-        <button>コード選択</button>
         <button
           id="start-btn"
           onClick={startBtnHandler}
@@ -27,8 +31,12 @@ export const CasualBattleWaitingRoom: React.FC<Props> = () => {
           マッチ開始
         </button>
       </div>
-      <button id="ready-btn" onClick={readyBtnHandler}>
-        準備完了
+      <button
+        id="ready-btn"
+        onClick={readyBtnHandler}
+        disabled={readyBtnDisabled}
+      >
+        {ready ? "取り消し" : "準備完了！"}
       </button>
       <button id="exit-btn" onClick={exitBtnHandler}>
         退出
@@ -43,16 +51,44 @@ export const CasualBattleWaitingRoom: React.FC<Props> = () => {
           {roomInfo.memberKeys.map((key) => (
             <li key={key}>
               {roomInfo.members[key].displayName} :{" "}
-              {
-                roomInfo.members[key].status == "watching" ? "観戦中" :
-                roomInfo.members[key].status == "disconnect" ? "切断" :
-                roomInfo.members[key].status == "waiting" ? roomInfo.members[key].ready ? "準備完了" : "準備中" :
-                "No Status"
-              }
+              {roomInfo.members[key].status == "watching"
+                ? "観戦中"
+                : roomInfo.members[key].status == "disconnect"
+                ? "切断"
+                : roomInfo.members[key].status == "waiting"
+                ? roomInfo.members[key].ready
+                  ? "準備完了"
+                  : "準備中"
+                : "No Status"}
             </li>
           ))}
         </ul>
       </ul>
+      <div>
+        <h3>コード選択</h3>
+        {code.loading ? (
+          "コード一覧を取得中"
+        ) : code.codes.length == 0 ? (
+          "コードが見つかりませんでした"
+        ) : (
+          <>
+            {code.codes.map((code) => (
+              <label key={code.id}>
+                <input
+                  type="radio"
+                  name="codes"
+                  value={code.id}
+                  checked={code.id === selectedCodeId}
+                  onChange={(e) => onChangeSelectedCodeId(e.target.value)}
+                />
+                ステップ：{code.step}, 作成日：{code.createdAt}, 内容:{" "}
+                {code.codeContent.slice(0, 10)}
+                <br />
+              </label>
+            ))}
+          </>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/pages/CasualBattle/WaitingRoom/WaitingRoom.tsx
+++ b/src/pages/CasualBattle/WaitingRoom/WaitingRoom.tsx
@@ -7,6 +7,7 @@ export const CasualBattleWaitingRoom: React.FC<Props> = () => {
   const {
     roomInfo,
     isHost,
+    status,
     readyBtnHandler,
     exitBtnHandler,
     startBtnDisabled,
@@ -35,13 +36,19 @@ export const CasualBattleWaitingRoom: React.FC<Props> = () => {
       <ul>
         <li>Room ID: {roomInfo.roomId}</li>
         <li>Host: {roomInfo.host.displayName}</li>
+        <li>Status: {status}</li>
         <li>I am {isHost ? "" : "not"} a host.</li>
         <li>Members:</li>
         <ul>
           {roomInfo.memberKeys.map((key) => (
             <li key={key}>
               {roomInfo.members[key].displayName} :{" "}
-              {roomInfo.members[key].ready ? "準備完了" : "準備中"}
+              {
+                roomInfo.members[key].status == "watching" ? "観戦中" :
+                roomInfo.members[key].status == "disconnect" ? "切断" :
+                roomInfo.members[key].status == "waiting" ? roomInfo.members[key].ready ? "準備完了" : "準備中" :
+                "No Status"
+              }
             </li>
           ))}
         </ul>

--- a/src/pages/CasualBattle/WaitingRoom/__snapshots__/WaitingRoom.test.tsx.snap
+++ b/src/pages/CasualBattle/WaitingRoom/__snapshots__/WaitingRoom.test.tsx.snap
@@ -7,9 +7,6 @@ Array [
       ルーム待機画面
     </div>
     <div>
-      <button>
-        コード選択
-      </button>
       <button
         disabled={false}
         id="start-btn"
@@ -19,10 +16,11 @@ Array [
       </button>
     </div>
     <button
+      disabled={false}
       id="ready-btn"
       onClick={[MockFunction]}
     >
-      準備完了
+      取り消し
     </button>
     <button
       id="exit-btn"
@@ -38,6 +36,10 @@ Array [
       <li>
         Host: 
         host user
+      </li>
+      <li>
+        Status: 
+        waiting
       </li>
       <li>
         I am 
@@ -58,16 +60,57 @@ Array [
           user 1
            :
            
-          準備完了
+          観戦中
         </li>
         <li>
           user 2
            :
            
-          準備完了
+          切断
         </li>
       </ul>
     </ul>
+    <div>
+      <h3>
+        コード選択
+      </h3>
+      <React.Fragment>
+        <label>
+          <input
+            checked={false}
+            name="codes"
+            onChange={[Function]}
+            type="radio"
+            value="hostCodeId1"
+          />
+          ステップ：
+          3
+          , 作成日：
+          2022-02-16T05:05:46.315585+09:00
+          , 内容:
+           
+          print('hel
+          <br />
+        </label>
+        <label>
+          <input
+            checked={false}
+            name="codes"
+            onChange={[Function]}
+            type="radio"
+            value="hostCodeId2"
+          />
+          ステップ：
+          3
+          , 作成日：
+          2022-02-16T10:00:46.315585+09:00
+          , 内容:
+           
+          alert('hel
+          <br />
+        </label>
+      </React.Fragment>
+    </div>
   </div>,
 ]
 `;

--- a/src/services/RoomSync/DBListener/DBListener.ts
+++ b/src/services/RoomSync/DBListener/DBListener.ts
@@ -43,7 +43,7 @@ import {
  * @param roomId ルームID
  * @returns dispatch関数
  */
-export const startRoomDBSync = (roomId: string): ThunkResult => {
+export const startRoomDBSync = (roomId: string): ThunkResult<void> => {
   return (dispatch: any) => {
     if (roomId == "") return;
     dispatch(
@@ -56,7 +56,7 @@ export const startRoomDBSync = (roomId: string): ThunkResult => {
  * ルーム情報の同期を終了する
  * @returns dispatch関数
  */
-export const stopRoomDBSync = (): ThunkResult => {
+export const stopRoomDBSync = (): ThunkResult<void> => {
   return (dispatch: any) => {
     dispatch(_stopValueDBSync("rooms"));
   };
@@ -67,7 +67,7 @@ export const stopRoomDBSync = (): ThunkResult => {
  * @param roomId ルームID
  * @returns dispatch用関数
  */
-export const startMembersDBSync = (roomId: string): ThunkResult => {
+export const startMembersDBSync = (roomId: string): ThunkResult<void> => {
   return (dispatch: any) => {
     if (roomId == "") return;
     dispatch(
@@ -87,7 +87,7 @@ export const startMembersDBSync = (roomId: string): ThunkResult => {
  * メンバーリストの同期を停止する
  * @returns dispatch用関数
  */
-export const stopMembersDBSync = (): ThunkResult => {
+export const stopMembersDBSync = (): ThunkResult<void> => {
   return (dispatch: any) => {
     dispatch(_stopListDBSync("members"));
   };
@@ -100,9 +100,16 @@ export const stopMembersDBSync = (): ThunkResult => {
  * @param value セットするユーザ状態
  * @returns なし
  */
-export const setUserStateOnDisconnect = async (roomId: string, userId: string, value: UserState) => {
-  if(userId == "") return;
-  await _setValueOnDisconnect(child(MembersRef(), `${roomId}/${userId}`), value);
+export const setUserStateOnDisconnect = async (
+  roomId: string,
+  userId: string,
+  value: UserState
+) => {
+  if (userId == "") return;
+  await _setValueOnDisconnect(
+    child(MembersRef(), `${roomId}/${userId}`),
+    value
+  );
 };
 
 /**
@@ -112,8 +119,12 @@ export const setUserStateOnDisconnect = async (roomId: string, userId: string, v
  * @param value 更新するユーザ状態
  * @returns なし
  */
-export const updateUserStateOnDisconnect = async (roomId: string, userId: string, value: UserStateUpdate) => {
-  if(userId == "") return;
+export const updateUserStateOnDisconnect = async (
+  roomId: string,
+  userId: string,
+  value: UserStateUpdate
+) => {
+  if (userId == "") return;
   await _updateOnDisconnect(child(MembersRef(), `${roomId}/${userId}`), value);
 };
 
@@ -123,8 +134,11 @@ export const updateUserStateOnDisconnect = async (roomId: string, userId: string
  * @param userId ユーザID
  * @returns なし
  */
-export const removeUserStateOnDisconnect = async (roomId: string, userId: string) => {
-  if(userId == "") return;
+export const removeUserStateOnDisconnect = async (
+  roomId: string,
+  userId: string
+) => {
+  if (userId == "") return;
   await _removeOnDisconnect(child(MembersRef(), `${roomId}/${userId}`));
 };
 
@@ -136,9 +150,18 @@ export const removeUserStateOnDisconnect = async (roomId: string, userId: string
  * @param priority 優先度
  * @returns なし
  */
-export const setUserStateWithPriorityOnDisconnect = async (roomId: string, userId: string, value: UserState, priority: string | number | null) => {
-  if(userId == "") return;
-  await _setWithPriorityOnDisconnect(child(MembersRef(), `${roomId}/${userId}`), value, priority);
+export const setUserStateWithPriorityOnDisconnect = async (
+  roomId: string,
+  userId: string,
+  value: UserState,
+  priority: string | number | null
+) => {
+  if (userId == "") return;
+  await _setWithPriorityOnDisconnect(
+    child(MembersRef(), `${roomId}/${userId}`),
+    value,
+    priority
+  );
 };
 
 /**
@@ -147,8 +170,11 @@ export const setUserStateWithPriorityOnDisconnect = async (roomId: string, userI
  * @param userId ユーザID
  * @returns なし
  */
-export const cancelUserStateOnDisconnect = async (roomId: string, userId: string, ) => {
-  if(userId == "") return;
+export const cancelUserStateOnDisconnect = async (
+  roomId: string,
+  userId: string
+) => {
+  if (userId == "") return;
   await _cancelOnDisconnect(child(MembersRef(), `${roomId}/${userId}`));
 };
 
@@ -157,7 +183,7 @@ export const cancelUserStateOnDisconnect = async (roomId: string, userId: string
  * @param roomId ルームID
  * @returns dispatch用関数
  */
-export const startActionsDBSync = (roomId: string): ThunkResult => {
+export const startActionsDBSync = (roomId: string): ThunkResult<void> => {
   return (dispatch: any) => {
     if (roomId == "") return;
     dispatch(
@@ -177,7 +203,7 @@ export const startActionsDBSync = (roomId: string): ThunkResult => {
  * アクションリストの同期を停止する
  * @returns dispatch用関数
  */
-export const stopActionsDBSync = (): ThunkResult => {
+export const stopActionsDBSync = (): ThunkResult<void> => {
   return (dispatch: any) => {
     dispatch(_stopListDBSync("actions"));
   };
@@ -201,7 +227,7 @@ const _startValueDBSync = (
   syncRef: Query,
   reducerFunc: _valueReducerFunc,
   removeReducerFunc?: _valueRemoveReducerFunc
-): ThunkResult => {
+): ThunkResult<void> => {
   return (dispatch: any) => {
     _setCallBackToSyncSingleData(callbackKey, syncRef, (ss: DataSnapshot) => {
       const data = ss.val();
@@ -218,7 +244,7 @@ const _startValueDBSync = (
   };
 };
 
-const _stopValueDBSync = (callbackKey: string): ThunkResult => {
+const _stopValueDBSync = (callbackKey: string): ThunkResult<void> => {
   return () => {
     _unsubscribeCallBackToSyncSingleData(callbackKey);
   };
@@ -246,7 +272,7 @@ const _startListDBSync = (
   updatedFunc: _listReducerFunc,
   movedFunc: _listReducerFunc,
   removedFunc: _listRemoveReducerFunc
-): ThunkResult => {
+): ThunkResult<void> => {
   return (dispatch: any) => {
     _setCallBackToSyncListData(
       callbackKey,
@@ -305,7 +331,7 @@ const _startListDBSync = (
  * @param callbackKey コールバックキー
  * @returns dispatch用関数
  */
-const _stopListDBSync = (callbackKey: string): ThunkResult => {
+const _stopListDBSync = (callbackKey: string): ThunkResult<void> => {
   return () => {
     _unsubscribeCallBackToSyncListData(callbackKey);
   };
@@ -393,7 +419,11 @@ const _removeOnDisconnect = async (ref: DatabaseReference) => {
   await onDisconnect(ref).remove();
 };
 
-const _setWithPriorityOnDisconnect = async (ref: DatabaseReference, value: any, priority: string | number | null) => {
+const _setWithPriorityOnDisconnect = async (
+  ref: DatabaseReference,
+  value: any,
+  priority: string | number | null
+) => {
   await onDisconnect(ref).setWithPriority(value, priority);
 };
 

--- a/src/services/RoomSync/DBOperator/DBOperator.test.ts
+++ b/src/services/RoomSync/DBOperator/DBOperator.test.ts
@@ -35,6 +35,7 @@ const users: { [id: string]: UserState } = {
   userId: {
     displayName: "user's name",
     ready: true,
+    status: "waiting",
   },
 };
 
@@ -134,6 +135,7 @@ describe("Test Cases for Reducers of DBOperator", () => {
       expect(updateMock).lastCalledWith("/RoomApp/members/roomId/" + user.id, {
         displayName: user.displayName,
         ready: false,
+        status: "waiting",
       });
     });
 

--- a/src/services/RoomSync/DBOperator/DBOperator.test.ts
+++ b/src/services/RoomSync/DBOperator/DBOperator.test.ts
@@ -48,7 +48,7 @@ const actions: { [id: string]: UserAction } = {
 const roomInfo: RoomInfo = {
   name: "room's name",
   host: "userId",
-  state: "waiting",
+  status: "waiting",
 };
 
 describe("Test Cases for Reducers of DBOperator", () => {

--- a/src/services/RoomSync/DBOperator/DBOperator.ts
+++ b/src/services/RoomSync/DBOperator/DBOperator.ts
@@ -29,12 +29,18 @@ export const getRoomAsync = async (roomId: string) => {
   //データが存在しない場合はundefined
   if (!data) return;
 
-  return {
+  //ルーム情報にキャスト
+  const roomInfo: RoomInfo = {
     name: data.name,
     host: data.host,
-    status: data.state,
+    status: data.status,
     analyzingResult: data.analyzingResult,
-  } as RoomInfo;
+  };
+
+  //チェック
+  if (!roomInfo.name || !roomInfo.host || !roomInfo.status) return;
+
+  return roomInfo;
 };
 
 /**
@@ -80,7 +86,11 @@ export const destroyRoomAsync = async (roomId: string) => {
 export const initMemberAsync = async (
   roomId: string,
   user: User,
-  userState: UserState = { displayName: user.displayName, status: "waiting", ready: false }
+  userState: UserState = {
+    displayName: user.displayName,
+    status: "waiting",
+    ready: false,
+  }
 ) => {
   await updateMemberAsync(roomId, user.id, userState);
 };

--- a/src/services/RoomSync/DBOperator/DBOperator.ts
+++ b/src/services/RoomSync/DBOperator/DBOperator.ts
@@ -14,6 +14,11 @@ import {
 
 // ---- Realtime DBへのset・update・push・removeファンクション群 ----- //
 
+/**
+ * ルーム情報を取得する
+ * @param roomId ルームID
+ * @returns ルーム情報
+ */
 export const getRoomAsync = async (roomId: string) => {
   if (roomId == "") return;
 
@@ -27,10 +32,16 @@ export const getRoomAsync = async (roomId: string) => {
   return {
     name: data.name,
     host: data.host,
-    state: data.state,
+    status: data.state,
+    analyzingResult: data.analyzingResult,
   } as RoomInfo;
 };
 
+/**
+ * ルーム情報を追加する
+ * @param roomInfo ルーム情報
+ * @returns DB上のルームへの参照
+ */
 export const pushRoomAsync = async (roomInfo: RoomInfo) => {
   const dbRef = await push(RoomsRef(), roomInfo);
   return dbRef;
@@ -40,7 +51,6 @@ export const pushRoomAsync = async (roomInfo: RoomInfo) => {
  * ルーム情報を更新する
  * @param roomId ルームID
  * @param roomInfo ルーム情報
- * @returns dispatch用関数
  */
 export const updateRoomAsync = async (
   roomId: string,
@@ -53,7 +63,6 @@ export const updateRoomAsync = async (
 /**
  * ルームを削除し、ルームに関連付いたメンバー・アクション情報をすべて削除する
  * @param roomId ルームID
- * @returns dispatch用関数
  */
 export const destroyRoomAsync = async (roomId: string) => {
   if (roomId == "") return;
@@ -71,7 +80,7 @@ export const destroyRoomAsync = async (roomId: string) => {
 export const initMemberAsync = async (
   roomId: string,
   user: User,
-  userState: UserState = { displayName: user.displayName, ready: false }
+  userState: UserState = { displayName: user.displayName, status: "waiting", ready: false }
 ) => {
   await updateMemberAsync(roomId, user.id, userState);
 };
@@ -81,7 +90,6 @@ export const initMemberAsync = async (
  * @param roomId ルームID
  * @param id メンバーID（ユーザID）
  * @param userState メンバー情報
- * @returns dispatch用関数
  */
 export const updateMemberAsync = async (
   roomId: string,
@@ -96,7 +104,6 @@ export const updateMemberAsync = async (
  * メンバーの削除をDBに送信する
  * @param roomId ルームID
  * @param id メンバーID（ユーザID）
- * @returns dispatch用関数
  */
 export const removeMemberAsync = async (roomId: string, id: string) => {
   if (roomId == "" || id == "") return;
@@ -107,7 +114,6 @@ export const removeMemberAsync = async (roomId: string, id: string) => {
  * アクションの追加をDBに送信する
  * @param roomId ルームID
  * @param userAction アクション情報
- * @returns dispatch用関数
  */
 export const addActionAsync = async (
   roomId: string,
@@ -122,7 +128,6 @@ export const addActionAsync = async (
  * @param roomId ルームID
  * @param id アクションID
  * @param userAction アクション情報
- * @returns dispatch用関数
  */
 export const updateActionAsync = async (
   roomId: string,
@@ -137,7 +142,6 @@ export const updateActionAsync = async (
  * アクションの削除をDBに送信する
  * @param roomId ルームID
  * @param id アクションID
- * @returns dispatch用関数
  */
 export const removeActionAsync = async (roomId: string, id: string) => {
   if (roomId == "" || id == "") return;

--- a/src/services/RoomSync/RoomSync.test.ts
+++ b/src/services/RoomSync/RoomSync.test.ts
@@ -38,7 +38,7 @@ const roomId = "room id";
 const roomInfo: RoomInfo = {
   name: "room name",
   host: "userid1",
-  state: "waiting",
+  status: "waiting",
 };
 const user1: UserState = {
   displayName: "user1",

--- a/src/services/RoomSync/RoomSync.test.ts
+++ b/src/services/RoomSync/RoomSync.test.ts
@@ -43,10 +43,12 @@ const roomInfo: RoomInfo = {
 const user1: UserState = {
   displayName: "user1",
   ready: false,
+  status: "waiting",
 };
 const user2: UserState = {
   displayName: "user1",
   ready: true,
+  status: "watching",
 };
 const action1: UserAction = {
   userId: "userid1",
@@ -146,6 +148,7 @@ describe("Test Cases for Reducers of RoomSync Service", () => {
           data: {
             displayName: "updated name",
             ready: false,
+            status: "watching",
           },
         })
       )
@@ -155,6 +158,7 @@ describe("Test Cases for Reducers of RoomSync Service", () => {
         userid1: {
           displayName: "updated name",
           ready: false,
+          status: "watching",
         },
       },
       sortedKeysOfMembers: ["userid1"],

--- a/src/services/RoomSync/RoomSync.ts
+++ b/src/services/RoomSync/RoomSync.ts
@@ -17,7 +17,15 @@ export const ActionsRef = () => child(RootRef(), "actions");
 export type RoomInfo = {
   name: string;
   host: string;
-  state: "waiting" | "analyzing" | "watching";
+  /**
+   * - waiting: 待機画面に居る
+   * - watching: GameWatching画面にいる
+   * - result: GameWatching画面で結果を表示している
+   */
+  status: "waiting" | "watching";
+  analyzingResult?: {
+    jsonPath: string;
+  };
 };
 
 /**
@@ -26,6 +34,17 @@ export type RoomInfo = {
  */
 export type UserState = {
   displayName: string;
+  /**
+   * - waiting: 待機画面に居る
+   * - watching: GameWatching画面にいる
+   * - disconnect: 接続が切れた
+   */
+  status: "waiting" | "watching" | "disconnect";
+  /**
+   * 選択したコードのID
+   */
+  codeId?: string;
+  //for CasualBattle/WaitingRoom
   ready: boolean;
 };
 

--- a/src/services/RoomSync/RoomSync.ts
+++ b/src/services/RoomSync/RoomSync.ts
@@ -1,7 +1,8 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { ref, child, getDatabase } from "firebase/database";
-import { Dispatch } from "redux";
+import { AnyAction } from "redux";
 import "firebase_config";
+import { ThunkAction } from "redux-thunk";
 
 import { RootState } from "store";
 
@@ -24,7 +25,8 @@ export type RoomInfo = {
    */
   status: "waiting" | "watching";
   analyzingResult?: {
-    jsonPath: string;
+    resultId?: string;
+    error?: string;
   };
 };
 
@@ -104,14 +106,19 @@ type UserStatePayload = ListPayload<UserState>; // Member Payload
 type UserActionPayload = ListPayload<UserAction>; // Action Payload
 
 // ---- DBアップデート用タイプ ---- //
-export type RoomInfoUpdate = Partial<RoomInfo>; // Room Update
-export type UserStateUpdate = Partial<UserState>; // Member Update
-export type UserActionUpdate = Partial<UserAction>; // Action Update
+// null：値を削除，undefined：更新しない
+type nullable<T> = {
+  [P in keyof T]?: T[P] | undefined | null;
+};
+export type RoomInfoUpdate = nullable<RoomInfo>; // Room Update
+export type UserStateUpdate = nullable<UserState>; // Member Update
+export type UserActionUpdate = nullable<UserAction>; // Action Update
 
-export type ThunkResult = (
-  dispatch: Dispatch<any>,
-  getState: () => RootState
-) => Promise<any> | any;
+export type ThunkResult<R> = ThunkAction<R, RootState, undefined, AnyAction>;
+// export type ThunkResult = (
+//   dispatch: Dispatch<any>,
+//   getState: () => RootState
+// ) => Promise<any> | any;
 
 /**
  * 初期状態


### PR DESCRIPTION
### 実装内容
- マッチ開始時の処理を実装
  1. ホストがシミュレーションを実行を要求
  2. バックエンドがシミュレーションを実行
  3. ホストがシミュレーション結果をfirebase DB経由で共有
  4. メンバー全員が結果を表示
- ルーム作成・入室ボタンの挙動を変更
  - 一度押したらエラー等の例外が発生するまで押せない
- 予測していない切断時の処理を実装
  - 切断時にユーザステータスをdisconnectに設定
  - ルーム内には残る