### PR TITLE
ルームの招待機能の実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,13 +15,12 @@ import { CodeList } from "pages/Code/CodeList/CodeList";
 import { PrivateRoute } from "utils/PrivateRoute";
 import { setCallBackToSyncUser } from "services/user/user";
 import { RootingScreen } from "components/RootingScreen/RootingScreen";
+import { CasualBattleInvitation } from "pages/CasualBattle/Invitation/Invitation";
 
 type Props = {};
 
 // react router はこのページが参考になるよ
 // https://reffect.co.jp/react/react-router#Link
-
-export const currentUser = React.createContext(undefined);
 
 export const App: React.FC<Props> = () => {
   const dispatch = useDispatch();
@@ -44,6 +43,10 @@ export const App: React.FC<Props> = () => {
             element={<CasualBattleWaitingRoom />}
           />
           <Route path="/casual-battle" element={<CasualBattleLobby />} />
+          <Route
+            path="/casual-battle/invitation/:roomId"
+            element={<CasualBattleInvitation />}
+          />
           <Route
             path="/casual-battle/search-room"
             element={<CasualBattleSearchRoom />}

--- a/src/components/RootingScreen/RootingScreen.tsx
+++ b/src/components/RootingScreen/RootingScreen.tsx
@@ -33,6 +33,9 @@ export const RootingScreen: React.FC<Props> = () => {
           <Link to="/casual-battle">カジュアルロビー画面</Link>
         </li>
         <li>
+          <Link to="/casual-battle/invitation">カジュアル対戦招待画面</Link>
+        </li>
+        <li>
           <Link to="/casual-battle/waiting-room">待機招待画面</Link>
         </li>
         <li>

--- a/src/components/RootingScreen/__snapshots__/RootingScreen.test.tsx.snap
+++ b/src/components/RootingScreen/__snapshots__/RootingScreen.test.tsx.snap
@@ -52,6 +52,13 @@ Array [
       </li>
       <li>
         <Link
+          to="/casual-battle/invitation"
+        >
+          カジュアル対戦招待画面
+        </Link>
+      </li>
+      <li>
+        <Link
           to="/casual-battle/waiting-room"
         >
           待機招待画面

--- a/src/components/SignInScreen/SignInScreen.tsx
+++ b/src/components/SignInScreen/SignInScreen.tsx
@@ -32,7 +32,7 @@ export const SignInScreen: React.FC<Props> = (props: Props) => {
   const navigate = useNavigate(); //router
 
   if (isLogin) {
-    navigate("/");
+    navigate(props.signInSuccessUrl ? props.signInSuccessUrl : "/");
   }
 
   //サインインのAsync

--- a/src/pages/CasualBattle/Invitation/Invitation.test.tsx
+++ b/src/pages/CasualBattle/Invitation/Invitation.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import { CasualBattleInvitation } from "./Invitation";
+import { IResponse, useInvitationState } from "./hooks/useInvitationState";
+
+jest.mock("./hooks/useInvitationState");
+
+const useSelectorMock = useInvitationState as jest.Mock;
+
+const state: IResponse = {
+  isLogin: true,
+  errorMessage: undefined,
+  roomId: "sampleID",
+  enterBtnDisabled: true,
+  enterBtnClickHandler: jest.fn(),
+};
+
+describe("<CasualBattleInvitation />", () => {
+  beforeEach(() => {
+    useSelectorMock.mockReturnValue({
+      ...state,
+    });
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("snapshot test", () => {
+    const wrapper = shallow(<CasualBattleInvitation />);
+    expect(wrapper.getElements()).toMatchSnapshot();
+  });
+
+  it("enter button test", () => {
+    const wrapper = shallow(<CasualBattleInvitation />);
+    const btn = wrapper.find("#enter-btn");
+    btn.simulate("click");
+
+    expect(state.enterBtnClickHandler).toHaveBeenCalled();
+  });
+});

--- a/src/pages/CasualBattle/Invitation/Invitation.tsx
+++ b/src/pages/CasualBattle/Invitation/Invitation.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { SignInScreen } from "components/SignInScreen/SignInScreen";
+import { useInvitationState } from "./hooks/useInvitationState";
+
+type Props = {};
+
+export const CasualBattleInvitation: React.FC<Props> = () => {
+  const {
+    isLogin,
+    errorMessage,
+    roomId,
+    enterBtnDisabled,
+    enterBtnClickHandler,
+  } = useInvitationState();
+
+  if (typeof roomId === "string") {
+    // if not login yet, Go to SignIn
+    if (isLogin == false) {
+      return (
+        <SignInScreen
+          signInSuccessUrl={`/casual-battle/invitation/${roomId}`}
+        />
+      );
+    }
+    //display enter button
+    else {
+      return (
+        <div>
+          <h1>次のルームに招待されています。</h1>
+          <p>RoomID:{roomId}</p>
+          <button
+            onClick={enterBtnClickHandler}
+            disabled={enterBtnDisabled}
+            id="enter-btn"
+          >
+            入場する
+          </button>
+        </div>
+      );
+    }
+  } else {
+    return <p>{errorMessage || "招待リンクが無効です"} </p>;
+  }
+};

--- a/src/pages/CasualBattle/Invitation/__snapshots__/Invitation.test.tsx.snap
+++ b/src/pages/CasualBattle/Invitation/__snapshots__/Invitation.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<CasualBattleInvitation /> snapshot test 1`] = `
+Array [
+  <div>
+    <h1>
+      次のルームに招待されています。
+    </h1>
+    <p>
+      RoomID:
+      sampleID
+    </p>
+    <button
+      disabled={true}
+      id="enter-btn"
+      onClick={[MockFunction]}
+    >
+      入場する
+    </button>
+  </div>,
+]
+`;

--- a/src/pages/CasualBattle/Invitation/hooks/useInvitationState.test.ts
+++ b/src/pages/CasualBattle/Invitation/hooks/useInvitationState.test.ts
@@ -1,0 +1,77 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import { Params, useNavigate, useParams } from "react-router-dom";
+
+import { useInvitationState } from "./useInvitationState";
+import { useRoomSync } from "hooks/RoomSyncHooks/useRoomSync";
+import { useSelector } from "react-redux";
+import { UserState } from "services/user/user";
+
+jest.mock("react-redux");
+jest.mock("react-router-dom");
+jest.mock("hooks/RoomSyncHooks/useRoomSync");
+
+const useRoomSyncMock = useRoomSync as jest.Mock;
+const useNavigateMock = useNavigate as jest.Mock;
+const useSelectorMock = useSelector as jest.Mock<UserState>;
+const useParamsMock = useParams as jest.Mock<Params<string>>;
+const initialRoomState = {
+  isEntered: false,
+  sortedKeysOfMembers: [],
+  members: {},
+  sortedKeysOfActions: [],
+  actions: {},
+};
+
+const initialRoomSyncState = {
+  room: { ...initialRoomState },
+  enterRoom: jest.fn(),
+};
+
+const navigateMock = jest.fn();
+
+describe("useWaitingRoomState", () => {
+  beforeEach(() => {
+    useRoomSyncMock.mockReturnValue({ ...initialRoomSyncState });
+    useNavigateMock.mockReturnValue(navigateMock);
+    initialRoomSyncState.enterRoom.mockResolvedValue({});
+    useSelectorMock.mockReturnValue({
+      user: null,
+      isLogin: true,
+      unRegisterObserver: null,
+    });
+    useParamsMock.mockReturnValue({
+      roomId: "1234",
+    });
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("render", () => {
+    const { result } = renderHook(() => useInvitationState());
+    expect(result.current).toBeTruthy();
+    expect(result.current.isLogin).toBe(true);
+  });
+
+  it("room.isEntered=trueでページ遷移", () => {
+    useRoomSyncMock.mockReturnValue({
+      ...initialRoomSyncState,
+      room: {
+        ...initialRoomState,
+        isEntered: true,
+      },
+    });
+    renderHook(() => useInvitationState());
+    expect(navigateMock).lastCalledWith("/casual-battle/waiting-room");
+  });
+  it("exec enterBtnClickHandler", () => {
+    const { result } = renderHook(() => useInvitationState());
+    const enterBtnClickHandler = result.current.enterBtnClickHandler;
+
+    expect(result.current.enterBtnDisabled).toBe(false);
+    act(() => {
+      enterBtnClickHandler();
+    });
+    expect(result.current.enterBtnDisabled).toBe(true);
+  });
+});

--- a/src/pages/CasualBattle/Invitation/hooks/useInvitationState.ts
+++ b/src/pages/CasualBattle/Invitation/hooks/useInvitationState.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { Params, useNavigate, useParams } from "react-router-dom";
+import { useRoomSync } from "hooks/RoomSyncHooks/useRoomSync";
+import { RootState } from "store";
+import { useSelector } from "react-redux";
+
+export type IResponse = {
+  isLogin: boolean;
+  errorMessage?: string;
+  roomId?: string;
+  enterBtnDisabled: boolean;
+  enterBtnClickHandler: () => void;
+};
+
+export const useInvitationState = (): IResponse => {
+  const { roomId } = useParams<Params<string>>();
+  const { isLogin } = useSelector((state: RootState) => state.user);
+  const [enterBtnDisabled, setEnterBtnDisabled] = useState(false);
+  const { room, enterRoom } = useRoomSync();
+  const [errorMessage, setErrorMessage] = useState<string | undefined>(
+    undefined
+  );
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (room.isEntered) {
+      navigate("/casual-battle/waiting-room");
+    }
+  }, [room.isEntered]);
+
+  //入場ボタン
+  const _enterBtnHandler = () => {
+    if (typeof roomId === "string") {
+      setEnterBtnDisabled(true);
+      enterRoom(roomId).catch(() => {
+        setEnterBtnDisabled(false);
+      });
+    } else {
+      setErrorMessage("招待リンクが無効です。");
+    }
+  };
+
+  return {
+    isLogin: isLogin,
+    errorMessage: errorMessage,
+    roomId: roomId,
+    enterBtnDisabled: enterBtnDisabled,
+    enterBtnClickHandler: _enterBtnHandler,
+  };
+};

--- a/src/pages/CasualBattle/WaitingRoom/WaitingRoom.test.tsx
+++ b/src/pages/CasualBattle/WaitingRoom/WaitingRoom.test.tsx
@@ -11,6 +11,8 @@ const useSelectorMock = useWaitingRoomState as jest.Mock;
 const state: IResponse = {
   roomInfo: {
     roomId: "room id",
+    invitationLink:
+      "http://localhost:3000/#/casual-battle/invitation/-MzESfkdu9Xmu8pkOAw5",
     host: {
       displayName: "host user",
       ready: false,
@@ -62,6 +64,8 @@ const state: IResponse = {
   exitBtnHandler: jest.fn(),
   startBtnDisabled: false,
   startBtnHandler: jest.fn(),
+  isCopyBtnClicked: false,
+  invitationBtnHandler: jest.fn(),
 
   code: {
     codes: [
@@ -143,5 +147,14 @@ describe("<CasualBattleWaitingRoom />", () => {
     });
     expect(state.onChangeSelectedCodeId).toBeCalledTimes(1);
     expect(state.onChangeSelectedCodeId).lastCalledWith("selectedCodeId");
+  });
+
+  it("copy button test", () => {
+    const wrapper = shallow(<CasualBattleWaitingRoom />);
+
+    const btn = wrapper.find("#invitation-btn");
+    btn.simulate("click");
+
+    expect(state.invitationBtnHandler).toHaveBeenCalled();
   });
 });

--- a/src/pages/CasualBattle/WaitingRoom/WaitingRoom.tsx
+++ b/src/pages/CasualBattle/WaitingRoom/WaitingRoom.tsx
@@ -14,6 +14,9 @@ export const CasualBattleWaitingRoom: React.FC<Props> = () => {
     exitBtnHandler,
     startBtnDisabled,
     startBtnHandler,
+    isCopyBtnClicked,
+    invitationBtnHandler,
+
     code,
     selectedCodeId,
     onChangeSelectedCodeId,
@@ -41,6 +44,18 @@ export const CasualBattleWaitingRoom: React.FC<Props> = () => {
       <button id="exit-btn" onClick={exitBtnHandler}>
         退出
       </button>
+      <div style={{ display: "flex" }}>
+        <input
+          type="text"
+          id="invitation-text"
+          value={roomInfo.invitationLink}
+          readOnly
+        ></input>
+        <button id="invitation-btn" onClick={invitationBtnHandler}>
+          招待リンクをコピーする
+        </button>
+        {isCopyBtnClicked && <p>コピーしました</p>}
+      </div>
       <ul>
         <li>Room ID: {roomInfo.roomId}</li>
         <li>Host: {roomInfo.host.displayName}</li>

--- a/src/pages/CasualBattle/WaitingRoom/__snapshots__/WaitingRoom.test.tsx.snap
+++ b/src/pages/CasualBattle/WaitingRoom/__snapshots__/WaitingRoom.test.tsx.snap
@@ -28,6 +28,26 @@ Array [
     >
       退出
     </button>
+    <div
+      style={
+        Object {
+          "display": "flex",
+        }
+      }
+    >
+      <input
+        id="invitation-text"
+        readOnly={true}
+        type="text"
+        value="http://localhost:3000/#/casual-battle/invitation/-MzESfkdu9Xmu8pkOAw5"
+      />
+      <button
+        id="invitation-btn"
+        onClick={[MockFunction]}
+      >
+        招待リンクをコピーする
+      </button>
+    </div>
     <ul>
       <li>
         Room ID: 

--- a/src/pages/CasualBattle/WaitingRoom/__snapshots__/WaitingRoom.test.tsx.snap
+++ b/src/pages/CasualBattle/WaitingRoom/__snapshots__/WaitingRoom.test.tsx.snap
@@ -69,38 +69,36 @@ Array [
       <li>
         Members:
       </li>
-      <ul>
-        <li>
-          host user
-           :
-           
-          準備中
-          <button
-            id="kick-btn-host-user-id"
-            onClick={[Function]}
-          >
-            キックする
-          </button>
-        </li>
-        <li>
-          user 1
-           :
-           
-          観戦中
-          <button
-            id="kick-btn-user-id-1"
-            onClick={[Function]}
-          >
-            キックする
-          </button>
-        </li>
-        <li>
-          user 2
-           :
-           
-          切断
-        </li>
-      </ul>
+      <li>
+        host user
+         :
+         
+        準備中
+        <button
+          id="kick-btn-host-user-id"
+          onClick={[Function]}
+        >
+          キックする
+        </button>
+      </li>
+      <li>
+        user 1
+         :
+         
+        観戦中
+        <button
+          id="kick-btn-user-id-1"
+          onClick={[Function]}
+        >
+          キックする
+        </button>
+      </li>
+      <li>
+        user 2
+         :
+         
+        切断
+      </li>
     </ul>
     <div>
       <h3>

--- a/src/pages/CasualBattle/WaitingRoom/hooks/useWaitingRoomState.test.ts
+++ b/src/pages/CasualBattle/WaitingRoom/hooks/useWaitingRoomState.test.ts
@@ -40,6 +40,7 @@ const initialRoomInfo: RoomInfo = {
 
 const initialRoomState: RoomState = {
   id: "room id",
+  invitationLink: "http://casual-room/invitation/roomId",
   isEntered: true,
   info: initialRoomInfo,
   sortedKeysOfMembers: ["userid1"],
@@ -99,6 +100,7 @@ describe("useWaitingRoomState", () => {
     const { result } = renderHook(() => useWaitingRoomState());
     expect(result.current.roomInfo).toEqual({
       roomId: "room id",
+      invitationLink: "http://casual-room/invitation/roomId",
       host: { ...users["userid1"] },
       memberKeys: ["userid1"],
       members: { userid1: users["userid1"] },
@@ -357,5 +359,9 @@ describe("useWaitingRoomState", () => {
       const { result } = renderHook(() => useWaitingRoomState());
       expect(result.current.startBtnDisabled).toBe(true);
     });
+  });
+
+  describe("isCopyBtnClicked", () => {
+    // TODO コピー部分のテストを書きたかったが難しかったため挫折...
   });
 });

--- a/src/pages/CasualBattle/WaitingRoom/hooks/useWaitingRoomState.test.ts
+++ b/src/pages/CasualBattle/WaitingRoom/hooks/useWaitingRoomState.test.ts
@@ -303,6 +303,7 @@ describe("useWaitingRoomState", () => {
     //初期値を確認
     expect(result.current.roomInfo).toEqual({
       roomId: "room id",
+      invitationLink: "http://casual-room/invitation/roomId",
       host: { ...users["userid1"] },
       memberKeys: ["userid1"],
       members: { userid1: users["userid1"] },

--- a/src/pages/CasualBattle/WaitingRoom/hooks/useWaitingRoomState.ts
+++ b/src/pages/CasualBattle/WaitingRoom/hooks/useWaitingRoomState.ts
@@ -146,11 +146,8 @@ export const useWaitingRoomState = (): IResponse => {
 
   //invitationURLのコピーボタン
   const _invitationBtnHandler = () => {
-    console.log(_invitationBtnHandler);
     if (room.invitationLink) {
-      console.log("faafwe");
       navigator.clipboard.writeText(room.invitationLink).then(() => {
-        console.log("aaa");
         setIsCopyBtnClicked(true);
       });
     }

--- a/src/pages/CasualBattle/WaitingRoom/hooks/useWaitingRoomState.ts
+++ b/src/pages/CasualBattle/WaitingRoom/hooks/useWaitingRoomState.ts
@@ -4,10 +4,10 @@ import { useNavigate } from "react-router-dom";
 import { useRoomSync } from "hooks/RoomSyncHooks/useRoomSync";
 import { CodeType, useFetchCodes } from "hooks/CodeAPIHooks/useFetchCodes";
 import { UserState, UserAction } from "services/RoomSync/RoomSync";
-
 export type IResponse = {
   roomInfo: {
     roomId: string;
+    invitationLink: string;
     host: UserState;
     memberKeys: string[];
     members: { [id: string]: UserState };
@@ -23,6 +23,8 @@ export type IResponse = {
   exitBtnHandler: () => void;
   startBtnDisabled: boolean;
   startBtnHandler: () => void;
+  isCopyBtnClicked: boolean;
+  invitationBtnHandler: () => void;
 
   code: {
     codes: CodeType[];
@@ -43,6 +45,7 @@ export const useWaitingRoomState = (): IResponse => {
   const [ready, setReady] = useState(false);
   const [readyBtnDisabled, setReadyBtnDisabled] = useState(true);
   const [startBtnDisabled, setStartBtnDisabled] = useState(true);
+  const [isCopyBtnClicked, setIsCopyBtnClicked] = useState(false);
   const navigate = useNavigate();
   const dummyUser: UserState = {
     displayName: "",
@@ -141,9 +144,22 @@ export const useWaitingRoomState = (): IResponse => {
     setSelectedCodeId(codeId);
   };
 
+  //invitationURLのコピーボタン
+  const _invitationBtnHandler = () => {
+    console.log(_invitationBtnHandler);
+    if (room.invitationLink) {
+      console.log("faafwe");
+      navigator.clipboard.writeText(room.invitationLink).then(() => {
+        console.log("aaa");
+        setIsCopyBtnClicked(true);
+      });
+    }
+  };
+
   return {
     roomInfo: {
       roomId: room.id ? room.id : "",
+      invitationLink: room.invitationLink ? room.invitationLink : "",
       host:
         room.info && room.info.host in room.members
           ? room.members[room.info.host]
@@ -156,13 +172,13 @@ export const useWaitingRoomState = (): IResponse => {
     isHost: isHost,
     status: room.info?.status,
     ready: ready,
-
     readyBtnHandler: _readyBtnHandler,
     readyBtnDisabled: readyBtnDisabled,
     exitBtnHandler: _exitBtnHandler,
     startBtnDisabled: startBtnDisabled,
     startBtnHandler: _startBtnHandler,
-
+    isCopyBtnClicked: isCopyBtnClicked,
+    invitationBtnHandler: _invitationBtnHandler,
     code: {
       codes: codes,
       loading: loading,

--- a/src/services/RoomSync/RoomSync.test.ts
+++ b/src/services/RoomSync/RoomSync.test.ts
@@ -26,6 +26,7 @@ childMock.mockImplementation((ref: any, path: string) => `${ref}/${path}`);
 
 const initialState: RoomState = {
   id: undefined,
+  invitationLink: undefined,
   isEntered: false,
   info: undefined,
   members: {},
@@ -62,6 +63,7 @@ const action2: UserAction = {
 const enteredState: RoomState = {
   ...initialState,
   id: roomId,
+  invitationLink: "http://localhost/#/casual-battle/invitation/room id",
   isEntered: true,
   info: { ...roomInfo },
 };

--- a/src/services/RoomSync/RoomSync.ts
+++ b/src/services/RoomSync/RoomSync.ts
@@ -3,7 +3,6 @@ import { ref, child, getDatabase } from "firebase/database";
 import { AnyAction } from "redux";
 import "firebase_config";
 import { ThunkAction } from "redux-thunk";
-
 import { RootState } from "store";
 
 export const RootRef = () => ref(getDatabase(), "/RoomApp");
@@ -64,6 +63,7 @@ export type UserAction = {
  */
 export type RoomState = {
   id?: string;
+  invitationLink?: string;
   isEntered: boolean;
   info?: RoomInfo;
   members: { [id: string]: UserState };
@@ -125,6 +125,7 @@ export type ThunkResult<R> = ThunkAction<R, RootState, undefined, AnyAction>;
  */
 const initialState: RoomState = {
   id: undefined,
+  invitationLink: undefined,
   info: undefined,
   isEntered: false,
   members: {},
@@ -137,9 +138,9 @@ const roomSlice = createSlice({
   name: "room",
   initialState: { ...initialState } as RoomState,
   reducers: {
-    // room
     enterRoom: (state, action: RoomPayload) => {
       state.id = action.payload.id;
+      state.invitationLink = `${window.location.origin}/#/casual-battle/invitation/${state.id}`;
       state.info = action.payload.data;
       state.isEntered = true;
     },


### PR DESCRIPTION
ルームIDが含まれたURLをクリックするとルームに入ることができるルーム招待機能を実装した。
[仕様書](https://www.notion.so/ea4344dedbb444818cb1aad0f7b6b612?p=db37e217425b4a0ca94815fe977ff8d4)

やったこと
- Invitationページ並びにhooksの作成
- ルーティングの作成
- waiting-roomに招待リンクコピーボタンの作成

<img width="935" alt="image" src="https://user-images.githubusercontent.com/45113742/160411500-2e53b3db-c5bf-4fd2-8af6-598fe26cc70c.png">


<img width="1275" alt="image" src="https://user-images.githubusercontent.com/45113742/160411550-8fe3e645-ee64-400f-ab34-7fd1c3e3e39d.png">



やってないこと
https://github.com/CodeParty2021/code_party_front/issues/30
