### PR TITLE
ログイン後のリンクバグを修正

### DIFF
--- a/src/pages/Start/components/FirebaseLoginForm/FirebaseLoginForm.tsx
+++ b/src/pages/Start/components/FirebaseLoginForm/FirebaseLoginForm.tsx
@@ -6,7 +6,7 @@ export const FirebaseLoginForm: React.FC<Props> = () => {
   return (
     <div>
       <p>ログイン情報を入力して!</p>
-      <SignInScreen signInSuccessUrl="/#/mode-select" />
+      <SignInScreen signInSuccessUrl="/mode-select" />
     </div>
   );
 };

--- a/src/pages/Start/components/FirebaseLoginForm/__snapshots__/FirebaseLoginForm.test.tsx.snap
+++ b/src/pages/Start/components/FirebaseLoginForm/__snapshots__/FirebaseLoginForm.test.tsx.snap
@@ -7,7 +7,7 @@ Array [
       ログイン情報を入力して!
     </p>
     <SignInScreen
-      signInSuccessUrl="/#/mode-select"
+      signInSuccessUrl="/mode-select"
     />
   </div>,
 ]


### PR DESCRIPTION
ログイン後のエンドポイントが間違っていた。
<img width="661" alt="image" src="https://user-images.githubusercontent.com/45113742/161274375-f947ccb3-5de3-4061-b52a-a5c4ed8db852.png">


エンドポイントを修正した。
<img width="613" alt="image" src="https://user-images.githubusercontent.com/45113742/161275313-2a9cc82a-26cb-4a40-9a73-d6f78a55bd1c.png">
