### PR TITLE
Revert "ログイン後のリンクバグを修正"

### DIFF
--- a/src/pages/Start/components/FirebaseLoginForm/FirebaseLoginForm.tsx
+++ b/src/pages/Start/components/FirebaseLoginForm/FirebaseLoginForm.tsx
@@ -6,7 +6,7 @@ export const FirebaseLoginForm: React.FC<Props> = () => {
   return (
     <div>
       <p>ログイン情報を入力して!</p>
-      <SignInScreen signInSuccessUrl="/mode-select" />
+      <SignInScreen signInSuccessUrl="/#/mode-select" />
     </div>
   );
 };

--- a/src/pages/Start/components/FirebaseLoginForm/__snapshots__/FirebaseLoginForm.test.tsx.snap
+++ b/src/pages/Start/components/FirebaseLoginForm/__snapshots__/FirebaseLoginForm.test.tsx.snap
@@ -7,7 +7,7 @@ Array [
       ログイン情報を入力して!
     </p>
     <SignInScreen
-      signInSuccessUrl="/mode-select"
+      signInSuccessUrl="/#/mode-select"
     />
   </div>,
 ]


### PR DESCRIPTION
Reverts CodeParty2021/code_party_front#35

isLogin時のurlは修正できていたがsignInSucdcessUrlが修正できていなかった。

isLoginはreact-roterで指定しているがsignInSucdcessUrlはFirebaseでリダイレクトしており、Firebaseのほうがhistoryモードに対応していなかったのが原因。