### PR TITLE
ログイン後のURLミスを修正

### DIFF
--- a/src/components/SignInScreen/SignInScreen.tsx
+++ b/src/components/SignInScreen/SignInScreen.tsx
@@ -17,7 +17,9 @@ export const SignInScreen: React.FC<Props> = (props: Props) => {
   // firebase ui のコンフィグ
   const uiConfig = {
     signInFlow: "popup",
-    signInSuccessUrl: props.signInSuccessUrl ? props.signInSuccessUrl : "/", // 成功後の遷移先
+    signInSuccessUrl: props.signInSuccessUrl
+      ? "/#" + props.signInSuccessUrl
+      : "/#", // 成功後の遷移先
     signInOptions: [
       firebase.auth.GoogleAuthProvider.PROVIDER_ID,
       firebase.auth.EmailAuthProvider.PROVIDER_ID,


### PR DESCRIPTION
下ブランチの修正
https://github.com/CodeParty2021/code_party_front/pull/35

isLogin時のurlは修正できていたがsignInSucdcessUrlが修正できていなかった。

isLoginはreact-roterで指定しているがsignInSucdcessUrlはFirebaseでリダイレクトしており、Firebaseのほうがhistoryモードに対応していなかったのが原因。