### PR TITLE
jsonIdを使わないように修正

### DIFF
--- a/src/hooks/CodeAPIHooks/useCodeAPI.ts
+++ b/src/hooks/CodeAPIHooks/useCodeAPI.ts
@@ -42,7 +42,6 @@ export type CreateCodeResponseType = CodeType;
 
 export type TestCodeResponseType = {
   unityURL: string;
-  jsonId: string;
   json: JSONLog;
 };
 export type JSONLog = {

--- a/src/hooks/CodeAPIHooks/useCodeAPI.ts
+++ b/src/hooks/CodeAPIHooks/useCodeAPI.ts
@@ -43,6 +43,16 @@ export type CreateCodeResponseType = CodeType;
 export type TestCodeResponseType = {
   unityURL: string;
   jsonId: string;
+  json:JSONLog;
+};
+export type JSONLog = {
+  turn: TurnState[];
+};
+export type TurnState = {
+  players: PlayerState[];
+};
+export type PlayerState = {
+  print: string;
 };
 
 export const useCodeAPI = (): IResponse => {

--- a/src/hooks/CodeAPIHooks/useCodeAPI.ts
+++ b/src/hooks/CodeAPIHooks/useCodeAPI.ts
@@ -43,7 +43,7 @@ export type CreateCodeResponseType = CodeType;
 export type TestCodeResponseType = {
   unityURL: string;
   jsonId: string;
-  json:JSONLog;
+  json: JSONLog;
 };
 export type JSONLog = {
   turn: TurnState[];

--- a/src/pages/Code/Coding/hooks/useCodeHooks.tsx
+++ b/src/pages/Code/Coding/hooks/useCodeHooks.tsx
@@ -1,24 +1,11 @@
-import { AxiosResponse } from "axios";
 import React, { useEffect, useRef, useState } from "react";
 import { UnityContext } from "react-unity-webgl";
-import { uri } from "config";
 import { useNavigate, useParams } from "react-router-dom";
-import { axiosWithIdToken } from "axios_config";
-import { useCodeAPI, CodeType } from "hooks/CodeAPIHooks/useCodeAPI";
+import { useCodeAPI, CodeType, TurnState } from "hooks/CodeAPIHooks/useCodeAPI";
 
 export type RunResponse = {
   unityURL: string;
   jsonId: string;
-};
-
-type JSONLog = {
-  turn: TurnState[];
-};
-type TurnState = {
-  players: PlayerState[];
-};
-type PlayerState = {
-  print: string;
 };
 
 export type IResponse = {
@@ -117,13 +104,9 @@ export const useCodingState = () => {
     if (isCode(code)) {
       setCode({ ...code, codeContent: inputCode });
       await updateCode(code.id, code.codeContent, code.step, code.language);
-      const { jsonId } = await testCode(code.id);
-      axiosWithIdToken
-        .get(`${uri}/results/${jsonId}/json/`, {})
-        .then((response: AxiosResponse<JSONLog>) => {
-          setJson(JSON.stringify(response.data));
-          setTurnLog(response.data.turn);
-        });
+      const { json } = await testCode(code.id);
+      setJson(JSON.stringify(json));
+      setTurnLog(json.turn);
     }
   };
 


### PR DESCRIPTION
testではResultAPIを使わないようになったので，フロントでもjsonIdを叩かないように修正
ローカルではバックエンドはfix-run-simlatorブランチで動作確認．フリーコーディングと対戦画面１人で正常動作