### PR TITLE
再レンダリング画家からにバグを修正

### DIFF
--- a/src/pages/Code/Coding/Coding.test.tsx
+++ b/src/pages/Code/Coding/Coding.test.tsx
@@ -33,7 +33,7 @@ const initialState: IResponse = {
     },
   ],
   handleEditorDidMount: jest.fn(),
-  setShowUnity: jest.fn(),
+  closeEditorButtonHandler: jest.fn(),
   unityContext: new UnityContext({
     loaderUrl: "unity/sp/web.loader.js",
     dataUrl: "unity/sp/web.data.unityweb",

--- a/src/pages/Code/Coding/Coding.tsx
+++ b/src/pages/Code/Coding/Coding.tsx
@@ -87,7 +87,7 @@ export const CodeCoding: React.FC<Props> = () => {
     execCode,
     turnLog,
     handleEditorDidMount,
-    setShowUnity,
+    closeEditorButtonHandler,
     showUnity,
     unityContext,
   } = useCodingState();
@@ -120,7 +120,9 @@ export const CodeCoding: React.FC<Props> = () => {
           </RightBox>
         </FlexBox>
         <Modal shown={showUnity}>
-          <CloseButton onClick={() => setShowUnity(false)}>×</CloseButton>
+          <CloseButton onClick={() => closeEditorButtonHandler()}>
+            ×
+          </CloseButton>
           <Unity
             unityContext={unityContext}
             style={{ width: "800px", height: "600px" }}

--- a/src/pages/Code/Coding/hooks/useCodeHooks.test.tsx
+++ b/src/pages/Code/Coding/hooks/useCodeHooks.test.tsx
@@ -32,7 +32,6 @@ describe("useWaitingRoomState", () => {
 
   it("render", () => {
     const { result } = renderHook(() => useCodingState());
-    console.log(result);
     //TODO: write test here
   });
 });

--- a/src/pages/Code/Coding/hooks/useCodeHooks.test.tsx
+++ b/src/pages/Code/Coding/hooks/useCodeHooks.test.tsx
@@ -31,7 +31,7 @@ describe("useWaitingRoomState", () => {
   });
 
   it("render", () => {
-    const { result } = renderHook(() => useCodingState());
+    renderHook(() => useCodingState());
     //TODO: write test here
   });
 });

--- a/src/pages/Code/Coding/hooks/useCodeHooks.tsx
+++ b/src/pages/Code/Coding/hooks/useCodeHooks.tsx
@@ -16,7 +16,7 @@ export type IResponse = {
   execCode: (content: string, step: string, language: string) => void;
   turnLog: TurnState[];
   handleEditorDidMount: (editor: any, _monaco: any) => void;
-  setShowUnity: React.Dispatch<React.SetStateAction<boolean>>;
+  closeEditorButtonHandler: () => void;
   showUnity: boolean;
   unityContext: UnityContext;
 };
@@ -73,7 +73,8 @@ export const useCodingState = () => {
     });
   }, []);
 
-  const [showUnity, setShowUnity] = useState(false);
+  const [showUnity, setShowUnity] = useState(false); // unityの表示フラグ
+
   const editorRef = useRef(
     null
   ) as React.MutableRefObject<null | HTMLInputElement>;
@@ -86,24 +87,28 @@ export const useCodingState = () => {
     // @ts-ignore
     return editorRef.current?.getValue();
   }
+
   const loadJson = (json: string) => {
     //unityContext.send("JSONLoader", "LoadJSON", json);
     unityContext.send("ReactUnityConnector", "SetSimulationData", json);
     unityContext.send("ReactUnityConnector", "LoadStage", "SquarePaint");
   };
 
+  // jsonに値が入ればunity描画、空が入ればunity非表示
   useEffect(() => {
     setShowUnity(json !== ""); //jsonがセットされている場合はUnityを表示する
     loadJson(json);
   }, [json]);
 
+  // unityモーダルを閉じる
+  const _closeEditorButtonHandler = () => {
+    setJson("");
+  };
+
   const execCode = async () => {
     const inputCode = getInputCode();
-    console.log("inputCode:", inputCode);
-    console.log("setCode:", { ...code, codeContent: inputCode });
     if (isCode(code)) {
       setCode({ ...code, codeContent: inputCode });
-      console.log("code:", code);
       await updateCode(code.id, inputCode, code.step, code.language);
       const { json } = await testCode(code.id);
       setJson(JSON.stringify(json));
@@ -119,7 +124,7 @@ export const useCodingState = () => {
     execCode,
     turnLog,
     handleEditorDidMount,
-    setShowUnity,
+    closeEditorButtonHandler: _closeEditorButtonHandler,
     showUnity,
     unityContext,
   };


### PR DESCRIPTION
# やったこと
コーディング画面にて、一度実行後、バツボタンでモーダルを閉じた後もう一度実行ボタンを押した際、jsonに変化がなかった場合においてのみUnityモーダルが描画されないバグが発生していた。
上のバグを修正した

# レビュー項目
- [ ] ローカルで動作確認して上の減少が発生しないか