### PR TITLE
selectmodeページのデザイン完了

### DIFF
--- a/src/pages/Event/SelectMode/SelectMode.test.tsx
+++ b/src/pages/Event/SelectMode/SelectMode.test.tsx
@@ -11,6 +11,7 @@ const initialState: IResponse = {
   loading: false,
   error: undefined,
   beginTrainHandler: () => {},
+  beginBattleHandler: () => {},
 };
 
 describe("<EventSelectMode />", () => {

--- a/src/pages/Event/SelectMode/SelectMode.tsx
+++ b/src/pages/Event/SelectMode/SelectMode.tsx
@@ -1,24 +1,30 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { ModeSelectCard } from "./components/ModeSelectCard/ModeSelectCard";
 import { useSelectModeState } from "./hooks/useSelectModeState";
+import { InnerBox, MarginBox } from "./SelectModeStyle";
 
 type Props = {};
 
 export const EventSelectMode: React.FC<Props> = () => {
-  const { loading, beginTrainHandler } = useSelectModeState();
+  const { loading, beginTrainHandler, beginBattleHandler } =
+    useSelectModeState();
   if (loading) {
     return <div>ロード中</div>;
   }
   return (
-    <div>
-      <button onClick={beginTrainHandler}>
-        <h3>1.くんれんモード</h3>
-      </button>
-      <Link to="/event/select-ai">
-        <button>
-          <h3>2.たいせんモード</h3>
-        </button>
-      </Link>
-    </div>
+    <InnerBox>
+      <MarginBox>
+        <ModeSelectCard
+          mode={"solo"}
+          onClick={beginTrainHandler}
+        ></ModeSelectCard>
+      </MarginBox>
+      <MarginBox>
+        <ModeSelectCard
+          mode={"battle"}
+          onClick={beginBattleHandler}
+        ></ModeSelectCard>
+      </MarginBox>
+    </InnerBox>
   );
 };

--- a/src/pages/Event/SelectMode/SelectModeStyle.tsx
+++ b/src/pages/Event/SelectMode/SelectModeStyle.tsx
@@ -1,0 +1,15 @@
+import styled from "styled-components";
+
+export const EventSelectModeStyle = styled.div``;
+
+export const MarginBox = styled.div`
+  margin: 48px;
+`;
+
+export const InnerBox = styled.div`
+  display: flex;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;

--- a/src/pages/Event/SelectMode/__snapshots__/SelectMode.test.tsx.snap
+++ b/src/pages/Event/SelectMode/__snapshots__/SelectMode.test.tsx.snap
@@ -2,23 +2,19 @@
 
 exports[`<EventSelectMode /> auth snapshot test 1`] = `
 Array [
-  <div>
-    <button
-      onClick={[Function]}
-    >
-      <h3>
-        1.くんれんモード
-      </h3>
-    </button>
-    <Link
-      to="/event/select-ai"
-    >
-      <button>
-        <h3>
-          2.たいせんモード
-        </h3>
-      </button>
-    </Link>
-  </div>,
+  <styled.div>
+    <styled.div>
+      <ModeSelectCard
+        mode="solo"
+        onClick={[Function]}
+      />
+    </styled.div>
+    <styled.div>
+      <ModeSelectCard
+        mode="battle"
+        onClick={[Function]}
+      />
+    </styled.div>
+  </styled.div>,
 ]
 `;

--- a/src/pages/Event/SelectMode/hooks/useSelectModeState.test.ts
+++ b/src/pages/Event/SelectMode/hooks/useSelectModeState.test.ts
@@ -81,4 +81,23 @@ describe("useSelectModeState", () => {
     expect(navigateMock).toBeCalledTimes(1);
     expect(navigateMock).lastCalledWith("/free-coding/123/");
   });
+  test("訓練モードが実行できる", async () => {
+    const apiState = initialUseCodeAPIState;
+    apiState.getCodesFilterStepIdAndUserId.mockReturnValue([]); //該当なし時はから配列が帰る
+    apiState.createCode.mockReturnValue({
+      id: "123",
+      codeContent: "print('hello');",
+      language: "1",
+      updatedAt: "20220303",
+      createdAt: "20220303",
+      user: "userid1",
+      step: "2",
+    });
+    const { result } = renderHook(() => useSelectModeState());
+
+    const { beginBattleHandler } = result.current;
+    await beginBattleHandler();
+    expect(navigateMock).toBeCalledTimes(1);
+    expect(navigateMock).lastCalledWith("/event/select-ai");
+  });
 });

--- a/src/pages/Event/SelectMode/hooks/useSelectModeState.ts
+++ b/src/pages/Event/SelectMode/hooks/useSelectModeState.ts
@@ -10,6 +10,7 @@ export type IResponse = {
   loading: boolean;
   error: string | undefined;
   beginTrainHandler: () => void;
+  beginBattleHandler: () => void;
 };
 
 export const useSelectModeState = (): IResponse => {
@@ -41,9 +42,15 @@ export const useSelectModeState = (): IResponse => {
       navigate(`/free-coding/${codeId}/`);
     }
   };
+
+  const _beginBattleHandler = () => {
+    navigate("/event/select-ai");
+  };
+
   return {
     loading: loading,
     error: error,
     beginTrainHandler: _beginTrainHandler,
+    beginBattleHandler: _beginBattleHandler,
   };
 };


### PR DESCRIPTION
# やったこと
- [モード選択画面](http://localhost:3000/#/event/select-mode)ページのデザインアップデート

<img width="1484" alt="image" src="https://user-images.githubusercontent.com/45113742/169262343-ad17057b-135e-40ec-8ebd-3a6fea8289b6.png">


- Linkで遷移していたがbuttonhandlerで遷移するように書き換えた。

# レビュー項目
- [ ] 自分の環境で２つのボタンが正しく表示されているか＋それぞれ遷移するか