### PR TITLE
select ai画面に戻るボタンの追加

### DIFF
--- a/src/pages/Event/SelectAI/SelectAI.test.tsx
+++ b/src/pages/Event/SelectAI/SelectAI.test.tsx
@@ -11,6 +11,7 @@ const initialState: IResponse = {
   loading: false,
   error: undefined,
   beginTrainHandler: () => {},
+  backButtonHandler: () => {},
 };
 
 describe("<EventSelectAI />", () => {

--- a/src/pages/Event/SelectAI/SelectAI.tsx
+++ b/src/pages/Event/SelectAI/SelectAI.tsx
@@ -4,7 +4,7 @@ import { useSelectAIState } from "./hooks/useSelectAIState";
 type Props = {};
 
 export const EventSelectAI: React.FC<Props> = () => {
-  const { loading, beginTrainHandler } = useSelectAIState();
+  const { loading, beginTrainHandler, backButtonHandler } = useSelectAIState();
   if (loading) {
     return <div>ロード中</div>;
   }
@@ -22,6 +22,7 @@ export const EventSelectAI: React.FC<Props> = () => {
       <button onClick={() => beginTrainHandler("6")}>
         <h3>ロボ4</h3>
       </button>
+      <button onClick={backButtonHandler}>戻る</button>
     </div>
   );
 };

--- a/src/pages/Event/SelectAI/__snapshots__/SelectAI.test.tsx.snap
+++ b/src/pages/Event/SelectAI/__snapshots__/SelectAI.test.tsx.snap
@@ -31,6 +31,11 @@ Array [
         ロボ4
       </h3>
     </button>
+    <button
+      onClick={[Function]}
+    >
+      戻る
+    </button>
   </div>,
 ]
 `;

--- a/src/pages/Event/SelectAI/hooks/useSelectAIState.test.ts
+++ b/src/pages/Event/SelectAI/hooks/useSelectAIState.test.ts
@@ -81,4 +81,25 @@ describe("useStartState", () => {
     expect(navigateMock).toBeCalledTimes(1);
     expect(navigateMock).lastCalledWith("/free-coding/123/");
   });
+
+  test("戻るボタンの実行", async () => {
+    const apiState = initialUseCodeAPIState;
+    apiState.getCodesFilterStepIdAndUserId.mockReturnValue([]);
+    apiState.createCode.mockReturnValue({
+      id: "123",
+      codeContent: "print('hello');",
+      language: "1",
+      updatedAt: "20220303",
+      createdAt: "20220303",
+      user: "userid1",
+      step: "2",
+    });
+
+    const { result } = renderHook(() => useSelectAIState());
+
+    const { backButtonHandler } = result.current;
+    backButtonHandler();
+    expect(navigateMock).toBeCalledTimes(1);
+    expect(navigateMock).lastCalledWith("/event/select-mode");
+  });
 });

--- a/src/pages/Event/SelectAI/hooks/useSelectAIState.ts
+++ b/src/pages/Event/SelectAI/hooks/useSelectAIState.ts
@@ -9,6 +9,7 @@ export type IResponse = {
   loading: boolean;
   error: string | undefined;
   beginTrainHandler: (stepId: string) => void;
+  backButtonHandler: () => void;
 };
 
 export const useSelectAIState = (): IResponse => {
@@ -31,9 +32,15 @@ export const useSelectAIState = (): IResponse => {
       navigate(`/free-coding/${codeId}/`);
     }
   };
+
+  const _backButtonHandler = () => {
+    navigate(`/event/select-mode`);
+  };
+
   return {
     loading: loading,
     error: error,
     beginTrainHandler: _beginTrainHandler,
+    backButtonHandler: _backButtonHandler,
   };
 };


### PR DESCRIPTION
# やったこと
[AI選択画面](http://localhost:3000/#/event/select-ai)に戻るボタンの追加
それに付随したテスト類の更新
<img width="265" alt="image" src="https://user-images.githubusercontent.com/45113742/169317381-760afc0a-0a10-40e1-be7f-53cc7620ee7d.png">


# レビュー内容
- [ ] ローカルでの動作確認
