### PR TITLE
OGPを設定

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-firebaseui": "^6.0.0",
+    "react-helmet-async": "^1.3.0",
     "react-hook-form": "^7.30.0",
     "react-redux": "7.2.6",
     "react-router-dom": "^6.3.0",
@@ -84,7 +85,9 @@
     ]
   },
   "jest": {
-    "snapshotSerializers": ["enzyme-to-json/serializer"]
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
+    ]
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.11",

--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
+  <head prefix="og: http://ogp.me/ns#">
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { HashRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { Top } from "./pages/Top/Top";
 import { StageList } from "./pages/Stage/StageList";
 import { Stage } from "./pages/Stage/Stage";
@@ -45,7 +45,7 @@ export const App: React.FC<Props> = () => {
 
   return (
     <div>
-      <HashRouter>
+      <BrowserRouter>
         <Routes>
           <Route path="/" element={<Top />} />
           <Route path="/stages" element={<StageList />} />
@@ -98,7 +98,7 @@ export const App: React.FC<Props> = () => {
           />
         </Routes>
         {isDev && <RootingScreen />}
-      </HashRouter>
+      </BrowserRouter>
     </div>
   );
 };

--- a/src/components/Head/Head.test.tsx
+++ b/src/components/Head/Head.test.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { Head } from "./Head";
+describe("<Head />", () => {
+  it("Head snapshot test", () => {
+    const wrapper = shallow(<Head title="title" />);
+
+    expect(wrapper.getElements()).toMatchSnapshot();
+  });
+});

--- a/src/components/Head/Head.tsx
+++ b/src/components/Head/Head.tsx
@@ -25,7 +25,7 @@ export const Head: React.FC<Props> = ({
       <meta property="og:type" content={ogType} />
       <meta property="og:title" content={title} />
       <meta property="og:description" content={ogDescription} />
-      <meta property="og:site_name" content="アルゴズモ" />
+      <meta property="og:site_name" content="アルゴスモ" />
       <meta property="og:image" content={ogImage} />
       <meta property="og:image:width" content={ogImageWidth} />
       <meta property="og:image:height" content={ogImageHeight} />

--- a/src/components/Head/Head.tsx
+++ b/src/components/Head/Head.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { Helmet } from "react-helmet-async";
+
+type Props = {
+  title: string;
+  ogType?: "website" | "article";
+  ogDescription?: string;
+  ogImage?: string;
+  ogImageWidth?: string;
+  ogImageHeight?: string;
+};
+
+export const Head: React.FC<Props> = ({
+  title,
+  ogType = "website",
+  ogDescription,
+  ogImage = "https://ogimage.tsmallfield.com/img/ogp_1200x630.png",
+  ogImageWidth = "1200",
+  ogImageHeight = "630",
+}) => {
+  return (
+    <Helmet>
+      <title>{title} - ALGOSMO</title>
+      <meta property="og:url" content={window.location.href} />
+      <meta property="og:type" content={ogType} />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={ogDescription} />
+      <meta property="og:site_name" content="アルゴズモ" />
+      <meta property="og:image" content={ogImage} />
+      <meta property="og:image:width" content={ogImageWidth} />
+      <meta property="og:image:height" content={ogImageHeight} />
+    </Helmet>
+  );
+};

--- a/src/components/Head/__snapshots__/Head.test.tsx.snap
+++ b/src/components/Head/__snapshots__/Head.test.tsx.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Head /> Head snapshot test 1`] = `
+Array [
+  <Helmet
+    defer={true}
+    encodeSpecialCharacters={true}
+    prioritizeSeoTags={false}
+  >
+    <title>
+      title
+       - ALGOSMO
+    </title>
+    <meta
+      content="http://localhost/"
+      property="og:url"
+    />
+    <meta
+      content="website"
+      property="og:type"
+    />
+    <meta
+      content="title"
+      property="og:title"
+    />
+    <meta
+      property="og:description"
+    />
+    <meta
+      content="アルゴズモ"
+      property="og:site_name"
+    />
+    <meta
+      content="https://ogimage.tsmallfield.com/img/ogp_1200x630.png"
+      property="og:image"
+    />
+    <meta
+      content="1200"
+      property="og:image:width"
+    />
+    <meta
+      content="630"
+      property="og:image:height"
+    />
+  </Helmet>,
+]
+`;

--- a/src/components/Head/__snapshots__/Head.test.tsx.snap
+++ b/src/components/Head/__snapshots__/Head.test.tsx.snap
@@ -27,7 +27,7 @@ Array [
       property="og:description"
     />
     <meta
-      content="アルゴズモ"
+      content="アルゴスモ"
       property="og:site_name"
     />
     <meta

--- a/src/components/SignInScreen/SignInScreen.tsx
+++ b/src/components/SignInScreen/SignInScreen.tsx
@@ -23,7 +23,7 @@ export const SignInScreen: React.FC<Props> = (props: Props) => {
   const uiConfig: firebaseui.auth.Config = {
     autoUpgradeAnonymousUsers: true,
     signInFlow: "popup",
-    signInSuccessUrl: "/#" + redirectUrl, // 成功後の遷移先
+    signInSuccessUrl: redirectUrl, // 成功後の遷移先
     signInOptions: [
       firebase.auth.GoogleAuthProvider.PROVIDER_ID,
       firebase.auth.EmailAuthProvider.PROVIDER_ID,

--- a/src/hooks/RoomSyncHooks/useFetchHost.test.ts
+++ b/src/hooks/RoomSyncHooks/useFetchHost.test.ts
@@ -1,0 +1,57 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import {
+  getRoomAsync,
+  getMemberAsync,
+} from "services/RoomSync/DBOperator/DBOperator";
+import { RoomInfo, UserState } from "services/RoomSync/RoomSync";
+import { useFetchHost } from "./useFetchHost";
+
+jest.mock("react-redux");
+jest.mock("firebase_config");
+jest.mock("services/RoomSync/DBOperator/DBOperator");
+
+const getRoomAsyncMock = getRoomAsync as jest.Mock<
+  Promise<RoomInfo | undefined>
+>;
+const getMemberAsyncMock = getMemberAsync as jest.Mock<
+  Promise<UserState | undefined>
+>;
+
+describe("useFetchHost", () => {
+  beforeEach(() => {
+    getRoomAsyncMock.mockResolvedValue({
+      name: "roomName",
+      host: "hostId",
+      status: "waiting",
+    });
+    getMemberAsyncMock.mockResolvedValue({
+      displayName: "hostName",
+      status: "waiting",
+      ready: false,
+    });
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("正常系のテスト", async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useFetchHost());
+    const getHost = result.current.getHost;
+
+    // 実行
+    act(() => {
+      getHost("roomId");
+    });
+
+    await waitForNextUpdate();
+
+    // 実行値確認
+    expect(result.current.data).toEqual({
+      displayName: "hostName",
+      status: "waiting",
+      ready: false,
+    });
+    expect(result.current.error).toEqual(undefined);
+    expect(result.current.loading).toEqual(false);
+  });
+});

--- a/src/hooks/RoomSyncHooks/useFetchHost.ts
+++ b/src/hooks/RoomSyncHooks/useFetchHost.ts
@@ -1,0 +1,52 @@
+import { useCallback, useState } from "react";
+import {
+  getMemberAsync,
+  getRoomAsync,
+} from "services/RoomSync/DBOperator/DBOperator";
+import { UserState } from "services/RoomSync/RoomSync";
+
+export type IState = {
+  data?: UserState;
+  error?: Error;
+  loading: boolean;
+};
+
+export type IResponse = IState & {
+  getHost: (roomId: string) => void;
+};
+
+export const useFetchHost = (): IResponse => {
+  const [res, setRes] = useState<IState>({
+    loading: false,
+  });
+
+  const getHost = useCallback(
+    async (roomId: string) => {
+      setRes((prevState) => ({ ...prevState, loading: true }));
+
+      const roomInfo = await getRoomAsync(roomId);
+      if (!roomInfo) {
+        setRes({
+          error: new Error("部屋情報が見つかりませんでした。"),
+          loading: false,
+        });
+        return;
+      }
+      const memberInfo = await getMemberAsync(roomId, roomInfo.host);
+      if (!memberInfo) {
+        setRes({
+          error: new Error("ホストが見つかりませんでした。"),
+          loading: false,
+        });
+        return;
+      }
+      setRes({ data: memberInfo, loading: false });
+    },
+    [setRes]
+  );
+
+  return {
+    ...res,
+    getHost,
+  };
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,12 +7,15 @@ import reportWebVitals from "./reportWebVitals";
 import { Provider } from "react-redux";
 import { store } from "./store";
 import { GlobalStyle } from "styles/GlobalStyle/GlobalStyle";
+import { HelmetProvider } from "react-helmet-async";
 
 ReactDOM.render(
   <Provider store={store}>
     <React.StrictMode>
-      <GlobalStyle />
-      <App />
+      <HelmetProvider>
+        <GlobalStyle />
+        <App />
+      </HelmetProvider>
     </React.StrictMode>
   </Provider>,
   document.getElementById("root")

--- a/src/pages/CasualBattle/Invitation/Invitation.test.tsx
+++ b/src/pages/CasualBattle/Invitation/Invitation.test.tsx
@@ -14,6 +14,7 @@ const state: IResponse = {
   roomId: "sampleID",
   enterBtnDisabled: true,
   enterBtnClickHandler: jest.fn(),
+  hostName: "hostName",
 };
 
 describe("<CasualBattleInvitation />", () => {

--- a/src/pages/CasualBattle/Invitation/Invitation.tsx
+++ b/src/pages/CasualBattle/Invitation/Invitation.tsx
@@ -12,19 +12,29 @@ export const CasualBattleInvitation: React.FC<Props> = () => {
     roomId,
     enterBtnDisabled,
     enterBtnClickHandler,
-    hostId,
+    hostName,
   } = useInvitationState();
+  const header = (
+    <Head
+      title="ALGOSMO"
+      ogDescription={
+        hostName
+          ? `${hostName}からカジュアル対戦に招待されています！`
+          : "ルーム情報が見つかりませんでした。"
+      }
+      ogType="article"
+      ogImage="https://codeparty.netlify.app/img/modeselectcard_battle.png"
+      ogImageHeight="412"
+      ogImageWidth="616"
+    />
+  );
 
   if (typeof roomId === "string") {
     // if not login yet, Go to SignIn
     if (isLogin == false) {
       return (
         <>
-          <Head
-            title="招待されています"
-            ogDescription={`HostId:${hostId}からRoomId:${roomId}に招待されています。`}
-            ogType="article"
-          />
+          {header}
           <SignInScreen
             signInSuccessUrl={`/casual-battle/invitation/${roomId}`}
           />
@@ -35,11 +45,7 @@ export const CasualBattleInvitation: React.FC<Props> = () => {
     else {
       return (
         <div>
-          <Head
-            title="招待されています"
-            ogDescription={`HostId:${hostId}からRoomId:${roomId}に招待されています。`}
-            ogType="article"
-          />
+          {header}
           <h1>次のルームに招待されています。</h1>
           <p>RoomID:{roomId}</p>
           <button

--- a/src/pages/CasualBattle/Invitation/Invitation.tsx
+++ b/src/pages/CasualBattle/Invitation/Invitation.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { SignInScreen } from "components/SignInScreen/SignInScreen";
 import { useInvitationState } from "./hooks/useInvitationState";
+import { Head } from "components/Head/Head";
 
 type Props = {};
 
@@ -11,21 +12,34 @@ export const CasualBattleInvitation: React.FC<Props> = () => {
     roomId,
     enterBtnDisabled,
     enterBtnClickHandler,
+    hostId,
   } = useInvitationState();
 
   if (typeof roomId === "string") {
     // if not login yet, Go to SignIn
     if (isLogin == false) {
       return (
-        <SignInScreen
-          signInSuccessUrl={`/casual-battle/invitation/${roomId}`}
-        />
+        <>
+          <Head
+            title="招待されています"
+            ogDescription={`HostId:${hostId}からRoomId:${roomId}に招待されています。`}
+            ogType="article"
+          />
+          <SignInScreen
+            signInSuccessUrl={`/casual-battle/invitation/${roomId}`}
+          />
+        </>
       );
     }
     //display enter button
     else {
       return (
         <div>
+          <Head
+            title="招待されています"
+            ogDescription={`HostId:${hostId}からRoomId:${roomId}に招待されています。`}
+            ogType="article"
+          />
           <h1>次のルームに招待されています。</h1>
           <p>RoomID:{roomId}</p>
           <button

--- a/src/pages/CasualBattle/Invitation/__snapshots__/Invitation.test.tsx.snap
+++ b/src/pages/CasualBattle/Invitation/__snapshots__/Invitation.test.tsx.snap
@@ -3,6 +3,11 @@
 exports[`<CasualBattleInvitation /> snapshot test 1`] = `
 Array [
   <div>
+    <Head
+      ogDescription="HostId:undefinedからRoomId:sampleIDに招待されています。"
+      ogType="article"
+      title="招待されています"
+    />
     <h1>
       次のルームに招待されています。
     </h1>

--- a/src/pages/CasualBattle/Invitation/__snapshots__/Invitation.test.tsx.snap
+++ b/src/pages/CasualBattle/Invitation/__snapshots__/Invitation.test.tsx.snap
@@ -4,9 +4,12 @@ exports[`<CasualBattleInvitation /> snapshot test 1`] = `
 Array [
   <div>
     <Head
-      ogDescription="HostId:undefinedからRoomId:sampleIDに招待されています。"
+      ogDescription="hostNameからカジュアル対戦に招待されています！"
+      ogImage="https://codeparty.netlify.app/img/modeselectcard_battle.png"
+      ogImageHeight="412"
+      ogImageWidth="616"
       ogType="article"
-      title="招待されています"
+      title="ALGOSMO"
     />
     <h1>
       次のルームに招待されています。

--- a/src/pages/CasualBattle/Invitation/hooks/useInvitationState.test.ts
+++ b/src/pages/CasualBattle/Invitation/hooks/useInvitationState.test.ts
@@ -6,17 +6,23 @@ import { useRoomSync } from "hooks/RoomSyncHooks/useRoomSync";
 import { useSelector } from "react-redux";
 import { LoginUserState } from "services/user/user";
 import { getRoomAsync } from "services/RoomSync/DBOperator/DBOperator";
+import {
+  useFetchHost,
+  IResponse as IFetchHostResponse,
+} from "hooks/RoomSyncHooks/useFetchHost";
 
 jest.mock("react-redux");
 jest.mock("react-router-dom");
 jest.mock("hooks/RoomSyncHooks/useRoomSync");
 jest.mock("services/RoomSync/DBOperator/DBOperator");
+jest.mock("hooks/RoomSyncHooks/useFetchHost");
 
 const useRoomSyncMock = useRoomSync as jest.Mock;
 const useNavigateMock = useNavigate as jest.Mock;
 const useSelectorMock = useSelector as jest.Mock<LoginUserState>;
 const useParamsMock = useParams as jest.Mock<Params<string>>;
 const getRoomAsyncMock = getRoomAsync as jest.Mock;
+const useFetchHostMock = useFetchHost as jest.Mock;
 const initialRoomState = {
   isEntered: false,
   sortedKeysOfMembers: [],
@@ -28,6 +34,16 @@ const initialRoomState = {
 const initialRoomSyncState = {
   room: { ...initialRoomState },
   enterRoom: jest.fn(),
+};
+
+const initialFetchHostState: IFetchHostResponse = {
+  data: {
+    displayName: "hostName",
+    status: "waiting",
+    ready: false,
+  },
+  loading: false,
+  getHost: jest.fn(),
 };
 
 const navigateMock = jest.fn();
@@ -46,6 +62,7 @@ describe("useWaitingRoomState", () => {
     useParamsMock.mockReturnValue({
       roomId: "1234",
     });
+    useFetchHostMock.mockReturnValue({ ...initialFetchHostState });
   });
   afterEach(() => {
     jest.resetAllMocks();

--- a/src/pages/CasualBattle/Invitation/hooks/useInvitationState.test.ts
+++ b/src/pages/CasualBattle/Invitation/hooks/useInvitationState.test.ts
@@ -5,15 +5,18 @@ import { useInvitationState } from "./useInvitationState";
 import { useRoomSync } from "hooks/RoomSyncHooks/useRoomSync";
 import { useSelector } from "react-redux";
 import { LoginUserState } from "services/user/user";
+import { getRoomAsync } from "services/RoomSync/DBOperator/DBOperator";
 
 jest.mock("react-redux");
 jest.mock("react-router-dom");
 jest.mock("hooks/RoomSyncHooks/useRoomSync");
+jest.mock("services/RoomSync/DBOperator/DBOperator");
 
 const useRoomSyncMock = useRoomSync as jest.Mock;
 const useNavigateMock = useNavigate as jest.Mock;
 const useSelectorMock = useSelector as jest.Mock<LoginUserState>;
 const useParamsMock = useParams as jest.Mock<Params<string>>;
+const getRoomAsyncMock = getRoomAsync as jest.Mock;
 const initialRoomState = {
   isEntered: false,
   sortedKeysOfMembers: [],
@@ -33,6 +36,7 @@ describe("useWaitingRoomState", () => {
   beforeEach(() => {
     useRoomSyncMock.mockReturnValue({ ...initialRoomSyncState });
     useNavigateMock.mockReturnValue(navigateMock);
+    getRoomAsyncMock.mockResolvedValue(undefined);
     initialRoomSyncState.enterRoom.mockResolvedValue({});
     useSelectorMock.mockReturnValue({
       user: null,

--- a/src/pages/CasualBattle/Invitation/hooks/useInvitationState.ts
+++ b/src/pages/CasualBattle/Invitation/hooks/useInvitationState.ts
@@ -3,8 +3,7 @@ import { Params, useNavigate, useParams } from "react-router-dom";
 import { useRoomSync } from "hooks/RoomSyncHooks/useRoomSync";
 import { RootState } from "store";
 import { useSelector } from "react-redux";
-import { RoomInfo } from "services/RoomSync/RoomSync";
-import { getRoomAsync } from "services/RoomSync/DBOperator/DBOperator";
+import { useFetchHost } from "hooks/RoomSyncHooks/useFetchHost";
 
 export type IResponse = {
   isLogin: boolean;
@@ -12,7 +11,7 @@ export type IResponse = {
   roomId?: string;
   enterBtnDisabled: boolean;
   enterBtnClickHandler: () => void;
-  hostId?: string;
+  hostName?: string;
 };
 
 export const useInvitationState = (): IResponse => {
@@ -24,21 +23,13 @@ export const useInvitationState = (): IResponse => {
     undefined
   );
   const navigate = useNavigate();
-  const [roomInfo, setRoomInfo] = useState<RoomInfo | undefined>(undefined);
+  const { data: host, getHost } = useFetchHost();
 
   useEffect(() => {
     if (room.isEntered) {
       navigate("/casual-battle/waiting-room");
     }
   }, [room.isEntered]);
-
-  useEffect(() => {
-    if (roomId) {
-      getRoomAsync(roomId).then((data) => {
-        if (data) setRoomInfo(data);
-      });
-    }
-  }, [roomId]);
 
   //入場ボタン
   const _enterBtnHandler = () => {
@@ -52,12 +43,18 @@ export const useInvitationState = (): IResponse => {
     }
   };
 
+  useEffect(() => {
+    if (roomId) {
+      getHost(roomId);
+    }
+  }, []);
+
   return {
     isLogin: isLogin,
     errorMessage: errorMessage,
     roomId: roomId,
     enterBtnDisabled: enterBtnDisabled,
     enterBtnClickHandler: _enterBtnHandler,
-    hostId: roomInfo?.host,
+    hostName: host?.displayName,
   };
 };

--- a/src/pages/CasualBattle/Invitation/hooks/useInvitationState.ts
+++ b/src/pages/CasualBattle/Invitation/hooks/useInvitationState.ts
@@ -3,6 +3,8 @@ import { Params, useNavigate, useParams } from "react-router-dom";
 import { useRoomSync } from "hooks/RoomSyncHooks/useRoomSync";
 import { RootState } from "store";
 import { useSelector } from "react-redux";
+import { RoomInfo } from "services/RoomSync/RoomSync";
+import { getRoomAsync } from "services/RoomSync/DBOperator/DBOperator";
 
 export type IResponse = {
   isLogin: boolean;
@@ -10,6 +12,7 @@ export type IResponse = {
   roomId?: string;
   enterBtnDisabled: boolean;
   enterBtnClickHandler: () => void;
+  hostId?: string;
 };
 
 export const useInvitationState = (): IResponse => {
@@ -21,12 +24,21 @@ export const useInvitationState = (): IResponse => {
     undefined
   );
   const navigate = useNavigate();
+  const [roomInfo, setRoomInfo] = useState<RoomInfo | undefined>(undefined);
 
   useEffect(() => {
     if (room.isEntered) {
       navigate("/casual-battle/waiting-room");
     }
   }, [room.isEntered]);
+
+  useEffect(() => {
+    if (roomId) {
+      getRoomAsync(roomId).then((data) => {
+        if (data) setRoomInfo(data);
+      });
+    }
+  }, [roomId]);
 
   //入場ボタン
   const _enterBtnHandler = () => {
@@ -46,5 +58,6 @@ export const useInvitationState = (): IResponse => {
     roomId: roomId,
     enterBtnDisabled: enterBtnDisabled,
     enterBtnClickHandler: _enterBtnHandler,
+    hostId: roomInfo?.host,
   };
 };

--- a/src/services/RoomSync/DBOperator/DBOperator.test.ts
+++ b/src/services/RoomSync/DBOperator/DBOperator.test.ts
@@ -12,6 +12,7 @@ import {
   addActionAsync,
   updateActionAsync,
   removeActionAsync,
+  getMemberAsync,
 } from "./DBOperator";
 
 jest.mock("firebase/database");
@@ -86,6 +87,33 @@ describe("Test Cases for Reducers of DBOperator", () => {
 
     it("異常系２（roomIdが空文字列の場合）", async () => {
       const result = await getRoomAsync("");
+      expect(getMock).toBeCalledTimes(0);
+      expect(result).toBeFalsy();
+    });
+  });
+
+  describe("test of getMemberAsync", () => {
+    it("正常系", async () => {
+      getMock.mockResolvedValue({
+        val: () => users["userId"],
+      });
+      const result = await getMemberAsync("roomId", "userId");
+      expect(getMock).toBeCalledTimes(1);
+      expect(getMock).lastCalledWith("/RoomApp/members/roomId/userId");
+      expect(result).toEqual(users["userId"]);
+    });
+
+    it("異常系１（DB上で値が見つからなかった場合）", async () => {
+      getMock.mockResolvedValue({
+        val: () => {},
+      });
+      const result = await getMemberAsync("roomId", "userId");
+      expect(getMock).toBeCalledTimes(1);
+      expect(result).toBeFalsy();
+    });
+
+    it("異常系２（Idが空文字列の場合）", async () => {
+      const result = await getMemberAsync("", "");
       expect(getMock).toBeCalledTimes(0);
       expect(result).toBeFalsy();
     });

--- a/src/services/RoomSync/DBOperator/DBOperator.ts
+++ b/src/services/RoomSync/DBOperator/DBOperator.ts
@@ -44,6 +44,41 @@ export const getRoomAsync = async (roomId: string) => {
 };
 
 /**
+ * メンバー情報を取得する
+ * @param roomId ルームID
+ * @param memberId メンバーID
+ * @returns メンバー情報
+ */
+export const getMemberAsync = async (roomId: string, memberId: string) => {
+  if (roomId == "" || memberId == "") return;
+
+  //DBからGET
+  const ss = await get(child(child(MembersRef(), roomId), memberId));
+  const data = ss.val();
+
+  //データが存在しない場合はundefined
+  if (!data) return;
+
+  //メンバー情報にキャスト
+  const member: UserState = {
+    displayName: data.displayName,
+    ready: data.ready,
+    status: data.status,
+    codeId: data.codeId,
+  };
+
+  //チェック
+  if (
+    member.displayName === undefined ||
+    member.ready === undefined ||
+    member.status === undefined
+  )
+    return;
+
+  return member;
+};
+
+/**
  * ルーム情報を追加する
  * @param roomInfo ルーム情報
  * @returns DB上のルームへの参照

--- a/src/services/RoomSync/RoomSync.test.ts
+++ b/src/services/RoomSync/RoomSync.test.ts
@@ -63,7 +63,7 @@ const action2: UserAction = {
 const enteredState: RoomState = {
   ...initialState,
   id: roomId,
-  invitationLink: "http://localhost/#/casual-battle/invitation/room id",
+  invitationLink: "http://localhost/casual-battle/invitation/room id",
   isEntered: true,
   info: { ...roomInfo },
 };

--- a/src/services/RoomSync/RoomSync.ts
+++ b/src/services/RoomSync/RoomSync.ts
@@ -140,7 +140,7 @@ const roomSlice = createSlice({
   reducers: {
     enterRoom: (state, action: RoomPayload) => {
       state.id = action.payload.id;
-      state.invitationLink = `${window.location.origin}/#/casual-battle/invitation/${state.id}`;
+      state.invitationLink = `${window.location.origin}/casual-battle/invitation/${state.id}`;
       state.info = action.payload.data;
       state.isEntered = true;
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13446,7 +13446,7 @@ react-firebaseui@^6.0.0:
   dependencies:
     firebaseui "^6.0.0"
 
-react-helmet-async@^1.0.7:
+react-helmet-async@^1.0.7, react-helmet-async@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.3.0.tgz#7bd5bf8c5c69ea9f02f6083f14ce33ef545c222e"
   integrity sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==


### PR DESCRIPTION
# OGPを実装
- 招待URLに対してOGPヘッダーを付与するように実装
# その他の修正点
- OGPを動的につけるにあたってHashRouterをBrowserRouterに変更
  - 更に，BrowserRouterをNetlify上で動作させるために，netlify.tomlを追加し常にindex.htmlを参照するように修正
  - 今までハッシュを使用していたURLはハッシュなしに置き換えました
- ルームのホスト名を取得するためにservies/RoomSync/DBOperatorにgetMemberAsyncメソッドを追加
- #30 に対応
# OGPのスクリーンショット（Slackで確認）
![image](https://user-images.githubusercontent.com/26971566/171332704-5ab8bf89-8a42-46b1-bf6e-e247fb5e6e31.png)