### PR TITLE
ページリロード時、トップページにリダイレクトされるのを防ぐ

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,6 @@ export const App: React.FC<Props> = () => {
   );
   const dispatch = useDispatch();
   const isDev = process.env.NODE_ENV === "development";
-
   // ログイン監視リスナーをセット
   useEffect(() => {
     dispatch(setCallBackToSyncUser());

--- a/src/components/RootingScreen/RootingScreen.test.tsx
+++ b/src/components/RootingScreen/RootingScreen.test.tsx
@@ -15,6 +15,7 @@ describe("<RootingScreen />", () => {
       user: null,
       isLogin: false,
       unRegisterObserver: null,
+      loading: false,
     });
     useDispatchMock.mockReturnValue(jest.fn());
   });

--- a/src/components/SignInScreen/SignInScreen.test.tsx
+++ b/src/components/SignInScreen/SignInScreen.test.tsx
@@ -18,6 +18,7 @@ describe("<SignInScreen />", () => {
       user: null,
       isLogin: false,
       unRegisterObserver: null,
+      loading: false,
     });
     useDispatchMock.mockReturnValue(jest.fn());
   });

--- a/src/hooks/CodeAPIHooks/useFetchCodes.test.ts
+++ b/src/hooks/CodeAPIHooks/useFetchCodes.test.ts
@@ -31,6 +31,7 @@ describe("useFetchCodes", () => {
       },
       isLogin: false,
       unRegisterObserver: null,
+      loading: false,
     });
   });
   afterEach(() => {

--- a/src/hooks/RoomSyncHooks/useRoomSync.test.ts
+++ b/src/hooks/RoomSyncHooks/useRoomSync.test.ts
@@ -79,6 +79,7 @@ const initialRoomState: RoomState = {
 const userState: LoginUserState = {
   isLogin: true,
   unRegisterObserver: null,
+  loading: false,
   user: {
     id: "userid1",
     displayName: "user1",

--- a/src/pages/CasualBattle/Invitation/hooks/useInvitationState.test.ts
+++ b/src/pages/CasualBattle/Invitation/hooks/useInvitationState.test.ts
@@ -38,6 +38,7 @@ describe("useWaitingRoomState", () => {
       user: null,
       isLogin: true,
       unRegisterObserver: null,
+      loading: false,
     });
     useParamsMock.mockReturnValue({
       roomId: "1234",

--- a/src/pages/CasualBattle/WaitingRoom/hooks/useWaitingRoomState.test.ts
+++ b/src/pages/CasualBattle/WaitingRoom/hooks/useWaitingRoomState.test.ts
@@ -105,6 +105,7 @@ describe("useWaitingRoomState", () => {
       },
       isLogin: false,
       unRegisterObserver: null,
+      loading: false,
     });
   });
   afterEach(() => {

--- a/src/pages/Code/CodeList/hooks/getCodesHooks.test.tsx
+++ b/src/pages/Code/CodeList/hooks/getCodesHooks.test.tsx
@@ -37,6 +37,7 @@ describe("useFetchCodes", () => {
       },
       isLogin: false,
       unRegisterObserver: null,
+      loading: false,
     });
     useCodeAPIMock.mockReturnValue({
       createCode: createCodeMock,

--- a/src/pages/Event/SelectAI/hooks/useSelectAIState.test.ts
+++ b/src/pages/Event/SelectAI/hooks/useSelectAIState.test.ts
@@ -33,6 +33,7 @@ describe("useStartState", () => {
       },
       isLogin: false,
       unRegisterObserver: null,
+      loading: false,
     });
     useNavigateMock.mockReturnValue(navigateMock);
   });

--- a/src/services/RoomSync/DBListener/DBListener.test.ts
+++ b/src/services/RoomSync/DBListener/DBListener.test.ts
@@ -79,6 +79,7 @@ const initialState: RootState = {
     isLogin: false,
     unRegisterObserver: null,
     user: null,
+    loading: false,
   },
 };
 

--- a/src/services/user/user.test.ts
+++ b/src/services/user/user.test.ts
@@ -6,6 +6,7 @@ test("reducer test ( signIn and signOut ) ", () => {
     user: null,
     isLogin: false,
     unRegisterObserver: null,
+    loading: true,
   };
 
   const loginUser: User = {
@@ -29,11 +30,13 @@ test("reducer test ( signIn and signOut ) ", () => {
     },
     unRegisterObserver: null,
     isLogin: true,
+    loading: false,
   });
   // signout test
   expect(reducer(previousState, signOut())).toEqual({
     user: null,
     unRegisterObserver: null,
     isLogin: false,
+    loading: false,
   });
 });

--- a/src/services/user/user.ts
+++ b/src/services/user/user.ts
@@ -20,6 +20,7 @@ export type User = {
 export type LoginUserState = {
   user: User | null;
   isLogin: boolean;
+  loading: boolean; //loading中かどうか
   unRegisterObserver: firebase.Unsubscribe | null; // ログイン監視用のobserverのkill用メソッド
 };
 
@@ -48,11 +49,16 @@ const isUserAuthResponse = (data: any): data is UserAuthResponse => {
 
 const userSlice = createSlice({
   name: "users", //識別用の名前
-  initialState: { user: null, isLogin: false } as LoginUserState,
+  initialState: {
+    user: null,
+    isLogin: false,
+    loading: true,
+  } as LoginUserState,
   reducers: {
     signIn: (state, action: signInAction) => {
       state.isLogin = true;
       state.user = action.payload;
+      state.loading = false;
     },
     setUnRegisterObserver: (state, action: setUnRegisterObserverAction) => {
       state.unRegisterObserver = action.payload;
@@ -60,6 +66,7 @@ const userSlice = createSlice({
     signOut: (state) => {
       state.isLogin = false;
       state.user = null;
+      state.loading = false;
     },
     updateUserDisplayName: (state, action: PayloadAction<string>) => {
       if (isUser(state.user)) {
@@ -133,7 +140,7 @@ export const setCallBackToSyncUser = () => {
   return async (dispatch: any) => {
     const observer = onAuthStateChanged(getAuth(), (user) => {
       if (user) {
-        console.log(user);
+        console.log("setCallBackToSyncUser", user);
         dispatch(signInAsync(user));
       }
     });

--- a/src/utils/PrivateRoute.test.tsx
+++ b/src/utils/PrivateRoute.test.tsx
@@ -1,31 +1,32 @@
 import React from "react";
+import { renderHook } from "@testing-library/react-hooks";
 import { shallow } from "enzyme";
-import { CodeList } from "./CodeList";
 import { useSelector } from "react-redux";
-import { LoginUserState } from "services/user/user";
+import { PrivateRoute } from "./PrivateRoute";
+import { Top } from "pages/Top/Top";
 jest.mock("react-redux");
 jest.mock("react-router-dom");
 
-const useSelectorMock = useSelector as jest.Mock<LoginUserState>;
+const useSelectorMock = useSelector as jest.Mock;
 
-describe("<CodeList />", () => {
-  beforeEach(() => {
+describe("privateRoute", () => {
+  it("privateRoute snapshot test", () => {
     useSelectorMock.mockReturnValue({
       user: {
-        id: "few",
+        id: "userid1",
         displayName: "ffawefae",
         email: "feaeafa@fafe.com",
         picture: "fewfawefaewf.png",
         jwt: "feefawef390urjfo",
-        isAnonymous: false,
       },
-      isLogin: true,
+      isLogin: false,
       unRegisterObserver: null,
       loading: false,
     });
-  });
-  it("auth snapshot test", () => {
-    const wrapper = shallow(<CodeList />);
+    const wrapper = shallow(
+      <PrivateRoute component={Top} redirectUrl="/event" />
+    );
+
     expect(wrapper.getElements()).toMatchSnapshot();
   });
 });

--- a/src/utils/PrivateRoute.test.tsx
+++ b/src/utils/PrivateRoute.test.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { renderHook } from "@testing-library/react-hooks";
 import { shallow } from "enzyme";
 import { useSelector } from "react-redux";
 import { PrivateRoute } from "./PrivateRoute";

--- a/src/utils/PrivateRoute.tsx
+++ b/src/utils/PrivateRoute.tsx
@@ -12,8 +12,11 @@ export const PrivateRoute: React.FC<Props> = ({
   component: RouteComponent,
   redirectUrl, // していなければstartページに遷移する
 }) => {
-  const { isLogin } = useSelector((state: RootState) => state.user);
-  if (isLogin) {
+  const { isLogin, loading } = useSelector((state: RootState) => state.user);
+
+  if (loading) {
+    return <div> ロード中です</div>;
+  } else if (isLogin) {
     return <RouteComponent />;
   } else {
     return <Navigate to={redirectUrl || "/start"} />;

--- a/src/utils/__snapshots__/PrivateRoute.test.tsx.snap
+++ b/src/utils/__snapshots__/PrivateRoute.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`privateRoute privateRoute snapshot test 1`] = `
+Array [
+  <Navigate
+    to="/event"
+  />,
+]
+`;


### PR DESCRIPTION
/event/select-aiなどのログイン認証が必要とされるページでリロードすると/eventページもしくは/startページにリダイレクトされていた。

原因は再ログイン処理完了の前にPrivateRouteのログインチェックが走ってしまい、未ログイン判定となってしまっていた。

ログイン処理が完了するまではloading=trueとし、その間はloading画面を描画、loadingがfalseとなったときに、ログインチェックを行うことで、上の問題を解決した。