### PR TITLE
Feature/load

### DIFF
--- a/src/pages/Code/Coding/Coding.tsx
+++ b/src/pages/Code/Coding/Coding.tsx
@@ -23,7 +23,7 @@ import { LogPanel } from "./components/LogPanel/LogPanel";
 import { LogItem } from "./components/LogItem/LogItem";
 import { IconButton } from "components/IconButton/IconButton";
 import { ArrowLeft } from "components/icons";
-
+import { Loading } from "pages/Loading/Loading";
 type Props = {};
 
 export const CodeCoding: React.FC<Props> = () => {
@@ -41,6 +41,11 @@ export const CodeCoding: React.FC<Props> = () => {
     showLog,
     showError,
   } = useCodingState();
+  if (loading) {
+    return <div>
+      <Loading/>
+    </div>;
+  }
   return (
     <CodingStyle>
       <Background color="blue" />
@@ -67,7 +72,7 @@ export const CodeCoding: React.FC<Props> = () => {
             color="red"
             showInfo={!isCode(code)}
           />
-          <MessageStyle
+          <MessageStyle //ローディング中の文章、消してもいいかも？
             title="ローディングチュウ..."
             value="しばらくお待ちください"
             color="blue"

--- a/src/pages/Code/Coding/components/Load/Load.test.tsx
+++ b/src/pages/Code/Coding/components/Load/Load.test.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { Load } from "./Load";
+describe("<Load />", () => {
+  it("auth snapshot test", () => {
+    const wrapper = shallow(<Load />);
+
+    expect(wrapper.getElements()).toMatchSnapshot();
+  });
+});

--- a/src/pages/Code/Coding/components/Load/Load.tsx
+++ b/src/pages/Code/Coding/components/Load/Load.tsx
@@ -5,8 +5,10 @@ type Prop = {};
 
 export const Load: React.FC<Prop> = () => {
   return (
-    <div>
-      ロード中です
+    <div id="overlay">
+      <div id="content">
+        <p>ロード中です。</p>
+      </div>
     </div>
   );
 };

--- a/src/pages/Code/Coding/components/Load/Load.tsx
+++ b/src/pages/Code/Coding/components/Load/Load.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+
+type Prop = {};
+
+export const Load: React.FC<Prop> = () => {
+  return (
+    <div>
+      ロード中です
+    </div>
+  );
+};

--- a/src/pages/Event/SelectAI/SelectAI.tsx
+++ b/src/pages/Event/SelectAI/SelectAI.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Background } from "../components/Background";
 import { RobotLink } from "./components/RobotLink";
 import { useSelectAIState } from "./hooks/useSelectAIState";
+import { Loading } from "pages/Loading/Loading";
 import {
   Back,
   BackButton,
@@ -14,14 +15,13 @@ import {
   Title,
   TitleLabel,
 } from "./SelectAIStyle";
-import { Load } from "pages/Code/Coding/components/Load/Load";
 type Props = {};
 
 export const EventSelectAI: React.FC<Props> = () => {
   const { loading, beginTrainHandler, backButtonHandler } = useSelectAIState();
   if (loading) {
     return <div>
-      <Load/>
+      <Loading/>
     </div>;
   }
   return (

--- a/src/pages/Event/SelectAI/SelectAI.tsx
+++ b/src/pages/Event/SelectAI/SelectAI.tsx
@@ -14,13 +14,15 @@ import {
   Title,
   TitleLabel,
 } from "./SelectAIStyle";
-
+import { Load } from "pages/Code/Coding/components/Load/Load";
 type Props = {};
 
 export const EventSelectAI: React.FC<Props> = () => {
   const { loading, beginTrainHandler, backButtonHandler } = useSelectAIState();
   if (loading) {
-    return <div>ロード中</div>;
+    return <div>
+      <Load/>
+    </div>;
   }
   return (
     <>

--- a/src/pages/Event/SelectAI/SelectAIStyle.tsx
+++ b/src/pages/Event/SelectAI/SelectAIStyle.tsx
@@ -25,7 +25,7 @@ export const Back = styled.div`
 export const Title = styled.div`
   height: 25px;
   display:flex;
-  ${FlexGap({ gap: "32px" })}}
+  ${FlexGap({ gap: "32px" })}
   align-items:center;
   padding-bottom:29px;
 `;

--- a/src/pages/Event/SelectMode/SelectMode.tsx
+++ b/src/pages/Event/SelectMode/SelectMode.tsx
@@ -3,14 +3,16 @@ import { Background } from "../components/Background";
 import { ModeSelectCard } from "./components/ModeSelectCard/ModeSelectCard";
 import { useSelectModeState } from "./hooks/useSelectModeState";
 import { InnerBox, MarginBox } from "./SelectModeStyle";
-
+import { Load } from "pages/Code/Coding/components/Load/Load";
 type Props = {};
 
 export const EventSelectMode: React.FC<Props> = () => {
   const { loading, beginTrainHandler, beginBattleHandler } =
     useSelectModeState();
   if (loading) {
-    return <div>ロード中</div>;
+    return <div>
+      <Load/>
+    </div>;
   }
   return (
     <>

--- a/src/pages/Event/SelectMode/SelectMode.tsx
+++ b/src/pages/Event/SelectMode/SelectMode.tsx
@@ -3,7 +3,7 @@ import { Background } from "../components/Background";
 import { ModeSelectCard } from "./components/ModeSelectCard/ModeSelectCard";
 import { useSelectModeState } from "./hooks/useSelectModeState";
 import { InnerBox, MarginBox } from "./SelectModeStyle";
-import { Load } from "pages/Code/Coding/components/Load/Load";
+import { Loading } from "pages/Loading/Loading";
 type Props = {};
 
 export const EventSelectMode: React.FC<Props> = () => {
@@ -11,7 +11,7 @@ export const EventSelectMode: React.FC<Props> = () => {
     useSelectModeState();
   if (loading) {
     return <div>
-      <Load/>
+      <Loading/>
     </div>;
   }
   return (

--- a/src/pages/Event/SetName/SetName.tsx
+++ b/src/pages/Event/SetName/SetName.tsx
@@ -11,7 +11,7 @@ import {
 } from "./SetNameStyle";
 import { Balloon, SetNameModal, SetNameStyle } from "./SetNameStyle";
 type Props = {};
-import { Load } from "pages/Code/Coding/components/Load/Load";
+import { Loading } from "pages/Loading/Loading";
 
 export const EventSetName: React.FC<Props> = () => {
   const {
@@ -23,7 +23,7 @@ export const EventSetName: React.FC<Props> = () => {
   } = useSetNameState();
   if (loading) {
     return <div>
-      <Load/>
+      <Loading/>
     </div>;
   }
   return (

--- a/src/pages/Event/SetName/SetName.tsx
+++ b/src/pages/Event/SetName/SetName.tsx
@@ -10,8 +10,8 @@ import {
   NameInput,
 } from "./SetNameStyle";
 import { Balloon, SetNameModal, SetNameStyle } from "./SetNameStyle";
-
 type Props = {};
+import { Load } from "pages/Code/Coding/components/Load/Load";
 
 export const EventSetName: React.FC<Props> = () => {
   const {
@@ -22,7 +22,9 @@ export const EventSetName: React.FC<Props> = () => {
     btnDisabled,
   } = useSetNameState();
   if (loading) {
-    return <div>ロード中</div>;
+    return <div>
+      <Load/>
+    </div>;
   }
   return (
     <>

--- a/src/pages/Loading/Loading.test.tsx
+++ b/src/pages/Loading/Loading.test.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { Loading } from "./Loading";
+describe("<Load />", () => {
+  it("auth snapshot test", () => {
+    const wrapper = shallow(<Loading />);
+
+    expect(wrapper.getElements()).toMatchSnapshot();
+  });
+});

--- a/src/pages/Loading/Loading.tsx
+++ b/src/pages/Loading/Loading.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Background } from "pages/Event/components/Background";
+type Prop = {};
+
+export const Loading: React.FC<Prop> = () => {
+  return (
+    <div id="overlay">
+      <div id="content">
+        <p>ロード中です。</p>
+        <Background />
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
### やったこと
---
Loadコンポーネントの実装
各イベント画面でload時に画面に文字が表示されていたのをLoadコンポーネントを参照するように変更

### 確認して欲しいこと
---
Unityロードの時自分の環境では前のものも含めてロード画面が表示されないため、問題ないかの確認をして欲しいです。
問題なければおそらくLoadコンポーネントがオーバーレイして表示されると思います

### 留意事項
---
Load画面のデザインがfigmaなどを探したところまだ作成していないっぽかったので、デザインは未実装です

