### PR TITLE
一部URLを修正

### DIFF
--- a/src/components/icons/components/IconPrototype/IconPrototype.tsx
+++ b/src/components/icons/components/IconPrototype/IconPrototype.tsx
@@ -3,7 +3,7 @@ import React, { ComponentProps } from "react";
 import { ReactSVG } from "react-svg";
 import styled from "styled-components";
 
-export const IconsDir = () => "icons";
+export const IconsDir = () => "/icons";
 
 type IconStyleProps = {
   display?: "inline-block" | "block";

--- a/src/components/icons/components/IconPrototype/__snapshots__/IconPrototype.test.tsx.snap
+++ b/src/components/icons/components/IconPrototype/__snapshots__/IconPrototype.test.tsx.snap
@@ -7,7 +7,7 @@ Array [
     display="block"
     fill="red"
     size={16}
-    src="icons/adjust_16.svg"
+    src="/icons/adjust_16.svg"
     wrapper="span"
   />,
 ]

--- a/src/pages/CasualBattle/GameWatch/GameWatch.tsx
+++ b/src/pages/CasualBattle/GameWatch/GameWatch.tsx
@@ -6,10 +6,10 @@ import { useRunSimulation } from "./hooks/useRunSimulation";
 type Props = {};
 //TODO:ここstepかstageごとに変更する必要あり
 const unityContext = new UnityContext({
-  loaderUrl: "unity/sp/web.loader.js",
-  dataUrl: "unity/sp/web.data.unityweb",
-  frameworkUrl: "unity/sp/web.framework.js.unityweb",
-  codeUrl: "unity/sp/web.wasm.unityweb",
+  loaderUrl: "/unity/sp/web.loader.js",
+  dataUrl: "/unity/sp/web.data.unityweb",
+  frameworkUrl: "/unity/sp/web.framework.js.unityweb",
+  codeUrl: "/unity/sp/web.wasm.unityweb",
 });
 
 export const CasualBattleGameWatch: React.FC<Props> = () => {

--- a/src/pages/Code/Coding/hooks/useCodeHooks.tsx
+++ b/src/pages/Code/Coding/hooks/useCodeHooks.tsx
@@ -26,10 +26,10 @@ export type IResponse = {
 
 //TODO:ここstepかstageごとに変更する必要あり
 const unityContext = new UnityContext({
-  loaderUrl: "unity/sp/web.loader.js",
-  dataUrl: "unity/sp/web.data.unityweb",
-  frameworkUrl: "unity/sp/web.framework.js.unityweb",
-  codeUrl: "unity/sp/web.wasm.unityweb",
+  loaderUrl: "/unity/sp/web.loader.js",
+  dataUrl: "/unity/sp/web.data.unityweb",
+  frameworkUrl: "/unity/sp/web.framework.js.unityweb",
+  codeUrl: "/unity/sp/web.wasm.unityweb",
 });
 
 export const useCodingState = () => {


### PR DESCRIPTION
# 現象
- ハッシュルータからブラウザルータに変更したことで、いくつかのリソースアクセスに影響が出ていた

# 修正内容
- リソースURLの先頭に/が付いていないものに/を付けました
  - アイコンSVG画像へのパスを修正
  - Unity関連のパスを修正