### PR TITLE
ローカルエミュレータを使用するように変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,11 +26,14 @@ services:
     command: yarn start
     ports:
       - 4000:4000 # Emulator Suite UI
+      - 9099:9099 # Authentication
       #- 5000:5000 # Firebase Hosting
       #- 5001:5001 # Clound Functions
       - 9000:9000 # Realtime Database
       #- 8080:8080 # Cloud Firestore
       #- 8085:8085 # Cloud Pub/Sub
+      - 4400:4400 # Emuylator Hub
+      - 4500:4500 # Other reserved ports
   frontend:
     env_file:
       - .env

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,6 +50,7 @@ const Config = () => {
       messagingSenderId: process.env.REACT_APP_MESSAGING_SENDER_ID,
       appId: process.env.REACT_APP_FIREBASE_APPID,
       measurementId: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID,
+      databaseURL: process.env.REACT_APP_FIREBASE_DATABASE_URL,
     },
     uri: process.env.REACT_APP_DEV_URI,
     microCMS: {

--- a/src/firebase_config.ts
+++ b/src/firebase_config.ts
@@ -14,7 +14,8 @@ export const getIdToken = async () => {
   return getAuth().currentUser?.getIdToken();
 };
 
-if (process.env.NODE_ENV === "test" || process.env.NODE_ENV === "development") {
+// TODO: 現状はテスト環境にFirebase Emulatorsを立てれないのでテスト環境では接続しない
+if (process.env.NODE_ENV === "development") {
   connectAuthEmulator(getAuth(), "http://localhost:9099");
   connectDatabaseEmulator(getDatabase(getApp()), "localhost", 9000);
 }

--- a/src/firebase_config.ts
+++ b/src/firebase_config.ts
@@ -1,8 +1,11 @@
+// TODO:compat系はv8のライブラリをv9で動かす為のものなので、v8系の処理をなくせたら消したい
 import firebase from "firebase/compat/app";
 import "firebase/compat/auth";
 
+import { getApp } from "firebase/app";
+import { getAuth, connectAuthEmulator } from "firebase/auth";
+import { getDatabase, connectDatabaseEmulator } from "firebase/database";
 import { firebaseConfig } from "config";
-import { getAuth } from "firebase/auth";
 
 //firebaseの初期化
 firebase.initializeApp(firebaseConfig);
@@ -10,3 +13,8 @@ firebase.initializeApp(firebaseConfig);
 export const getIdToken = async () => {
   return getAuth().currentUser?.getIdToken();
 };
+
+if (process.env.NODE_ENV === "test" || process.env.NODE_ENV === "development") {
+  connectAuthEmulator(getAuth(), "http://localhost:9099");
+  connectDatabaseEmulator(getDatabase(getApp()), "localhost", 9000);
+}


### PR DESCRIPTION
# やったこと
- ローカルで立ててあるFirebaseに接続するように変更

# お知らせ
- フロントとバックエンドの環境変数を更新しているのでコピーし直してください
  - [フロント](https://www.notion.so/Frontend-env-6c50632c787043b4a34d58680bf9a4fe)
  - [バックエンド](https://www.notion.so/Backend-750a8dca400848d1a0ee8c8b1613d343)

# 心配どころ
- WebSocketが偶につながらなくなる
  - databaseURLを設定したことで改善したと思われるが、根本的な原因は不明
  - (更新) WebSocketでエラーが出たら、クッキー削除で治ります
- テスト環境はエミュレータに繋いでいない
  - そもそもGithubからFirebaseにアクセスできないっぽい（エラーが出る）
  - 現状はデータベースを更新する系のテストが無い