### PR TITLE
フロントエンドのDockerの修正

### DIFF
--- a/.docker/Dockerfile.backend
+++ b/.docker/Dockerfile.backend
@@ -19,3 +19,5 @@ RUN pipenv run python manage.py loaddata event.json
 RUN echo "if [[ -z \"\${VIRTUAL_ENV}\" ]]; then" >> /root/.bashrc && \
   echo "source \$(pipenv --venv)/bin/activate" >> /root/.bashrc && \
   echo "fi"                                    >> /root/.bashrc
+
+CMD ["pipenv", "run", "python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/.docker/Dockerfile.firebase
+++ b/.docker/Dockerfile.firebase
@@ -12,3 +12,5 @@ WORKDIR ${APP_ROOT}
 
 ADD ./.env.firebase ${APP_ROOT}/.env
 RUN yarn install
+
+CMD ["yarn", "start"]

--- a/.docker/Dockerfile.frontend
+++ b/.docker/Dockerfile.frontend
@@ -1,0 +1,12 @@
+FROM node:16.11.0
+
+RUN apt-get update -y
+
+ENV APP_ROOT /frontend
+WORKDIR ${APP_ROOT}
+
+ADD ./package-lock.json ${APP_ROOT}/package-lock.json
+ADD ./package.json ${APP_ROOT}/package.json
+ADD ./yarn.lock ${APP_ROOT}/yarn.lock
+
+RUN yarn install

--- a/.docker/Dockerfile.frontend
+++ b/.docker/Dockerfile.frontend
@@ -10,3 +10,5 @@ ADD ./package.json ${APP_ROOT}/package.json
 ADD ./yarn.lock ${APP_ROOT}/yarn.lock
 
 RUN yarn install
+
+CMD ["yarn", "start"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 # 環境構築（Docker）
 - dockerまたはdocker desktopをインストール
   - [docker desktopのインストールはこちらから](https://www.docker.com/products/docker-desktop/)
-- dockerを起動
+- dockerまたはdocker desktopを起動
 - リポジトリをクローン
 - プロジェクトディレクトリに以下のファイルを作成
   - .env
@@ -32,8 +32,9 @@ $ docker-compose up -d
 - node_modulesを作り直したい
   - まずはコンテナを削除
   - frontend-node-modulesというDocker Volumeを削除
-  - storybook-node-modulesというDocker Volumeを削除
   - `docker-compose up -d`を実行（環境丸ごと作り直したい場合は`docker-compose build --no-cache`）
+- node_modulesがホスト側にあるとDockerが正常に動作しない可能性があります
+  - Volumeのnode_modulesより、ホスト側のnode_modulesが優先的に参照される場合があるみたいです。
 
 # 環境構築（従来）
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     build:
       context: .
       dockerfile: ./.docker/Dockerfile.frontend
+    image: code_party_frontend
     volumes:
       - .:/frontend
       - frontend-node-modules:/frontend/node_modules
@@ -62,9 +63,7 @@ services:
       - .env
     environment:
       - WATCHPACK_POLLING=true
-    build:
-      context: .
-      dockerfile: ./.docker/Dockerfile.frontend
+    image: code_party_frontend
     volumes:
       - .:/storybook
       - frontend-node-modules:/storybook/node_modules
@@ -74,8 +73,7 @@ services:
     ports:
       - 6006:6006
     links:
-      - backend
-      - firebase
+      - frontend
 volumes:
   backend:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     image: code_party_frontend
     volumes:
       - .:/frontend
-      - frontend-node-modules:/frontend/node_modules
+      - node_modules:/frontend/node_modules
     tty: true
     working_dir: /frontend
     command: yarn start
@@ -66,7 +66,7 @@ services:
     image: code_party_frontend
     volumes:
       - .:/storybook
-      - frontend-node-modules:/storybook/node_modules
+      - node_modules:/storybook/node_modules
     tty: true
     working_dir: /storybook
     command: yarn storybook
@@ -76,7 +76,5 @@ services:
       - frontend
 volumes:
   backend:
-    driver: local
   firebase:
-    driver: local
-  frontend-node-modules:
+  node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3"
 services:
   backend:
+    container_name: code_party_backend
     env_file:
       - .env.backend
     build:
@@ -14,6 +15,7 @@ services:
     ports:
       - 8000:8000
   firebase:
+    container_name: code_party_firebase
     env_file:
       - .env.firebase
     build:
@@ -35,36 +37,26 @@ services:
       - 4400:4400 # Emuylator Hub
       - 4500:4500 # Other reserved ports
   frontend:
+    container_name: code_party_frontend
     env_file:
       - .env
-    image: node:16.11.0
+    environment:
+      - WATCHPACK_POLLING=true
+    build:
+      context: .
+      dockerfile: ./.docker/Dockerfile.frontend
     volumes:
       - .:/frontend
       - frontend-node-modules:/frontend/node_modules
     tty: true
     working_dir: /frontend
-    command: >
-      bash -c 'yarn && yarn start'
+    command: yarn start
     ports:
       - 3000:3000
+      - 6006:6006
     links:
       - backend
       - firebase
-  storybook:
-    env_file:
-      - .env
-    image: node:16.11.0
-    volumes:
-      - .:/frontend
-      - storybook-node-modules:/frontend/node_modules
-    tty: true
-    working_dir: /frontend
-    command: >
-      bash -c 'yarn && yarn storybook'
-    ports:
-      - 6006:6006
-    links:
-      - frontend
 volumes:
   backend:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,25 @@ services:
     command: yarn start
     ports:
       - 3000:3000
+    links:
+      - backend
+      - firebase
+  storybook:
+    container_name: code_party_storybook
+    env_file:
+      - .env
+    environment:
+      - WATCHPACK_POLLING=true
+    build:
+      context: .
+      dockerfile: ./.docker/Dockerfile.frontend
+    volumes:
+      - .:/storybook
+      - frontend-node-modules:/storybook/node_modules
+    tty: true
+    working_dir: /storybook
+    command: yarn storybook
+    ports:
       - 6006:6006
     links:
       - backend
@@ -63,4 +82,3 @@ volumes:
   firebase:
     driver: local
   frontend-node-modules:
-  storybook-node-modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,10 +65,10 @@ services:
       - WATCHPACK_POLLING=true
     image: code_party_frontend
     volumes:
-      - .:/storybook
-      - node_modules:/storybook/node_modules
+      - .:/frontend
+      - node_modules:/frontend/node_modules
     tty: true
-    working_dir: /storybook
+    working_dir: /frontend
     command: yarn storybook
     ports:
       - 6006:6006


### PR DESCRIPTION
# やったこと
- Dockerでホットリロードがかかるように修正
  - docker-compose.ymlの環境変数に`WATCHPACK_POLLING=true`を設定
- コンテナ名を付けました
  - フロントエンド：code_party_frontend
  - Storybook：code_party_storybook
  - バックエンド：code_party_backend
  - Firebase：code_party_firebase
- Dockerを軽量化
  - `yarn`タイミングをビルド時に変更
    - `docker-compose start`毎に`yarn`するのは重くてストレス
    - パッケージ更新時は`docker-compose build`をする必要あり
  - `code_party_storybook`のnode_modulesを`code_party_frontend`のnode_modulesと共通化
    - Volumeサイズが１つ1.3GBぐらいあった＋同じ内容、だったので共通化
    - buildは１つずつ走るけど、同時にbuildが走るとyarnがロックするかもしれん
# やってないこと
- 特に無し！