### PR TITLE
Backgroundの修正

### DIFF
--- a/src/components/StarBackground/StarBackground.tsx
+++ b/src/components/StarBackground/StarBackground.tsx
@@ -19,16 +19,18 @@ export const StarBackground: React.FC<Props> = ({
   ...styleProps
 }) => {
   return (
-    <StarBackgroundStyle {...styleProps}>
+    <>
       {children}
-      <Star1 color="purple" />
-      <Star2 color="purple" />
-      <Star3 color="yellow" />
-      <Star4 color="yellow" />
-      <Star5 color="pink" />
-      <Star6 color="purple" />
-      <Star7 color="blue" />
-      <Star8 color="pink" />
-    </StarBackgroundStyle>
+      <StarBackgroundStyle {...styleProps}>
+        <Star1 color="purple" />
+        <Star2 color="purple" />
+        <Star3 color="yellow" />
+        <Star4 color="yellow" />
+        <Star5 color="pink" />
+        <Star6 color="purple" />
+        <Star7 color="blue" />
+        <Star8 color="pink" />
+      </StarBackgroundStyle>
+    </>
   );
 };

--- a/src/components/StarBackground/StarBackgroundStyle.tsx
+++ b/src/components/StarBackground/StarBackgroundStyle.tsx
@@ -5,7 +5,7 @@ import { GRAY_10, GRAY_20 } from "styles/colors";
 export type StarBackgroundStyleProps = {};
 
 const defaultStyle = css`
-  position: relative;
+  position: absolute;
   width: 100vw;
   height: 100vh;
   background-image: linear-gradient(
@@ -23,6 +23,8 @@ const defaultStyle = css`
   background-position: 0 0;
   background-color: ${GRAY_10};
   z-index: -2;
+  top: 0;
+  left: 0;
 `;
 
 export const StarBackgroundStyle = styled.div`

--- a/src/components/StarBackground/__snapshots__/StarBackground.test.tsx.snap
+++ b/src/components/StarBackground/__snapshots__/StarBackground.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`<Button /> snapshot test 1`] = `
 }
 
 .c0 {
-  position: relative;
+  position: absolute;
   width: 100vw;
   height: 100vh;
   background-image: linear-gradient( 0deg, transparent calc(100% - 1px), #EAEBF1 calc(100% - 1px) ), linear-gradient( 90deg, transparent calc(100% - 1px), #EAEBF1 calc(100% - 1px) );
@@ -35,6 +35,8 @@ exports[`<Button /> snapshot test 1`] = `
   background-position: 0 0;
   background-color: #F5F6F8;
   z-index: -2;
+  top: 0;
+  left: 0;
 }
 
 .c2 {


### PR DESCRIPTION
# チケット
https://www.notion.so/063ef9879cfc4e37aa705e44558bd099?p=7e01a0d55bb644bd848f44da442610b2&pm=s
# もともと
![image](https://user-images.githubusercontent.com/45113742/197378205-593920dd-c677-449b-b41d-a0311e8adbf2.png)

```
const withComponentTemplate: ComponentStory<typeof StarBackground> = (args) => (
  <StarBackground {...args}>
    <AlgoHead />
  </StarBackground>
);
```
こんな感じで書くと、中のコンテンツが背景の後ろに潜り込んでしまう。

# 修正後
Event/components/Background.tsxを参考に修正した
![image](https://user-images.githubusercontent.com/45113742/197378067-7abebce7-b1ab-4adc-8f3a-f83cdacaa6fb.png)


# レビュー観点
- 動作確認だけでおけ


