### PR TITLE
PlayerPlateのデザインを実装

### DIFF
--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -41,6 +41,12 @@ Pink.args = {
   color: "pink",
 };
 
+export const Gray = Template.bind({});
+Gray.args = {
+  ...Default.args,
+  color: "gray",
+};
+
 export const HasIcon = Template.bind({});
 HasIcon.args = {
   ...Default.args,

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -39,4 +39,8 @@ describe("<Avatar />", () => {
   it("render test robot", () => {
     expect(render(<Avatar type="robot" />)).toBeTruthy();
   });
+
+  it("render test user gray", () => {
+    expect(render(<Avatar type="user" color="gray" />)).toBeTruthy();
+  });
 });

--- a/src/components/Avatar/AvatarStyle.tsx
+++ b/src/components/Avatar/AvatarStyle.tsx
@@ -4,7 +4,7 @@ import styled, { css } from "styled-components";
 import { avatar } from "styles/colors";
 
 export type AvatarStyleProps = {
-  color?: "default" | "turquoise" | "leaf" | "orange" | "pink";
+  color?: "default" | "turquoise" | "leaf" | "orange" | "pink" | "gray";
   type?: "user" | "anonymous" | "robot";
 };
 
@@ -65,6 +65,11 @@ const pinkStyle = css`
   background-color: ${avatar.pink.background};
 `;
 
+const grayStyle = css`
+  border-color: ${avatar.gray.border};
+  background-color: ${avatar.gray.background};
+`;
+
 const userStyle = css``;
 
 const anonymousStyle = css`
@@ -104,6 +109,8 @@ export const AvatarStyle = styled.div<AvatarStyleProps & PrivateProps>`
   ${({ type }) => type === "user" && userStyle}
   ${({ type }) => type === "anonymous" && anonymousStyle}
   ${({ type }) => type === "robot" && robotStyle}
+
+  ${({ color }) => color === "gray" && grayStyle}
 `;
 
 AvatarStyle.defaultProps = {

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import { Button } from "./Button";
+import { Times } from "components/icons";
 
 export default {
   title: "components/Button",
@@ -38,6 +39,15 @@ SmallGreen.args = {
   ...Default.args,
   color: "green",
   size: "S",
+};
+
+export const IconWhite = Template.bind({});
+IconWhite.args = {
+  ...Default.args,
+  color: "white",
+  size: "S",
+  icon: "left",
+  Icon: Times,
 };
 
 export const Disabled = Template.bind({});

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Button } from "./Button";
 import "jest-styled-components";
 import { render, shallow } from "enzyme";
+import { Times } from "components/icons";
 
 describe("<Button />", () => {
   it("snapshot test", () => {
@@ -31,6 +32,21 @@ describe("<Button />", () => {
   it("render test green L", () => {
     expect(
       render(<Button color="green" size="L" status="default" value="テスト" />)
+    ).toBeTruthy();
+  });
+
+  it("render test white S icon", () => {
+    expect(
+      render(
+        <Button
+          color="white"
+          size="S"
+          status="default"
+          value="テスト"
+          icon="left"
+          Icon={Times}
+        />
+      )
     ).toBeTruthy();
   });
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,14 +1,17 @@
-import React from "react";
-import { ButtonStyle, ButtonStyleProps } from "./ButtonStyle";
+import React, { ComponentType } from "react";
+import { Icon16 } from "types/utils";
+import { ButtonStyle, ButtonStyleProps, IconProps } from "./ButtonStyle";
 
 type Props = ButtonStyleProps & {
   icon?: "right" | "left" | null;
+  Icon?: ComponentType<Icon16>;
   value?: string;
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
 };
 
 export const Button: React.FC<Props> = ({
   icon,
+  Icon,
   value,
   onClick,
   ...styleProps
@@ -20,9 +23,9 @@ export const Button: React.FC<Props> = ({
       {...styleProps}
     >
       <div className="frame">
-        {icon == "left" && <div>icon</div>}
+        {icon == "left" && Icon && <Icon {...IconProps(styleProps)} />}
         <span>{value}</span>
-        {icon == "right" && <div>icon</div>}
+        {icon == "right" && Icon && <Icon {...IconProps(styleProps)} />}
       </div>
     </ButtonStyle>
   );

--- a/src/components/Button/ButtonStyle.tsx
+++ b/src/components/Button/ButtonStyle.tsx
@@ -2,9 +2,10 @@ import styled, { css } from "styled-components";
 import { button } from "styles/colors";
 import { FONT_WEIGHT } from "styles/constants/constants";
 import { FlexGap } from "styles/FlexGap/FlexGap";
+import { Icon16 } from "types/utils";
 
 export type ButtonStyleProps = {
-  color?: "black" | "blue" | "pink" | "green";
+  color?: "black" | "blue" | "pink" | "green" | "white";
   size?: "S" | "M" | "L";
   status?: "default" | "disabled";
 };
@@ -63,6 +64,15 @@ const greenStyle = css`
   }
 `;
 
+const whiteStyle = css`
+  background: ${button.white.side};
+  color: ${button.white.font};
+  .frame {
+    border: 1px solid ${button.white.side};
+    background: ${button.white.surface};
+  }
+`;
+
 const sStyle = css`
   border-radius: 8px;
   padding-bottom: 4px;
@@ -101,8 +111,10 @@ const lStyle = css`
 
 const disabledStyle = css`
   background: ${button.disabled.side};
+  color: ${button.font};
   .frame {
     background: ${button.disabled.surface};
+    border: none;
     & > * {
       opacity: 0.2;
     }
@@ -122,6 +134,7 @@ export const ButtonStyle = styled.button<ButtonStyleProps>`
   ${({ color }) => color == "blue" && blueStyle}
   ${({ color }) => color == "pink" && pinkStyle}
   ${({ color }) => color == "green" && greenStyle}
+  ${({ color }) => color == "white" && whiteStyle}
 
   ${({ size }) => size == "S" && sStyle}
   ${({ size }) => size == "M" && mStyle}
@@ -134,4 +147,26 @@ ButtonStyle.defaultProps = {
   color: "black",
   size: "M",
   status: "default",
+};
+
+export const IconProps = ({ color, status }: ButtonStyleProps): Icon16 => {
+  const fill =
+    status === "disabled"
+      ? button.black.font
+      : color === "black"
+      ? button.black.font
+      : color === "blue"
+      ? button.blue.font
+      : color === "pink"
+      ? button.pink.font
+      : color === "green"
+      ? button.green.font
+      : color === "white"
+      ? button.white.font
+      : button.black.font;
+
+  return {
+    size: 16,
+    fill: fill,
+  };
 };

--- a/src/components/PlayerPlate/Me/PlayerPlateMe.stories.tsx
+++ b/src/components/PlayerPlate/Me/PlayerPlateMe.stories.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { PlayerPlateMe } from "./PlayerPlateMe";
+
+export default {
+  title: "components/PlayerPlate/PlayerPlateMe",
+  component: PlayerPlateMe,
+} as ComponentMeta<typeof PlayerPlateMe>;
+
+const Template: ComponentStory<typeof PlayerPlateMe> = (args) => (
+  <PlayerPlateMe {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  userName: "ほげ太郎",
+  userPhoto: "/logo512.png",
+  badge: "宇宙の探究者",
+  color: "turquoise",
+  status: "default",
+  selectedCodeName: "ランダムに進むロボット.py",
+};
+
+export const OrangeReady = Template.bind({});
+OrangeReady.args = {
+  ...Default.args,
+  color: "orange",
+  status: "ready",
+};
+
+export const Leaf = Template.bind({});
+Leaf.args = {
+  ...Default.args,
+  color: "leaf",
+};
+
+export const Magenta = Template.bind({});
+Magenta.args = {
+  ...Default.args,
+  color: "magenta",
+};

--- a/src/components/PlayerPlate/Me/PlayerPlateMe.test.tsx
+++ b/src/components/PlayerPlate/Me/PlayerPlateMe.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { PlayerPlateMe } from "./PlayerPlateMe";
+import "jest-styled-components";
+import { render } from "enzyme";
+
+describe("<PlayerPlateMe />", () => {
+  const defaultProps = {
+    userName: "ほげ太郎",
+    userPhoto: "/logo512.png",
+    badge: "宇宙の探究者",
+    color: "turquoise",
+    status: "default",
+    selectedCodeName: "ランダムに進むロボット.py",
+  } as const;
+
+  it("snapshot test", () => {
+    const wrapper = render(<PlayerPlateMe {...defaultProps} />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("render test turquoise default", () => {
+    expect(
+      render(
+        <PlayerPlateMe {...defaultProps} color="turquoise" status="default" />
+      )
+    ).toBeTruthy();
+  });
+
+  it("render test orange ready", () => {
+    expect(
+      render(<PlayerPlateMe {...defaultProps} color="orange" status="ready" />)
+    ).toBeTruthy();
+  });
+
+  it("render test leaf", () => {
+    expect(
+      render(<PlayerPlateMe {...defaultProps} color="leaf" />)
+    ).toBeTruthy();
+  });
+
+  it("render test magenta", () => {
+    expect(
+      render(<PlayerPlateMe {...defaultProps} color="magenta" />)
+    ).toBeTruthy();
+  });
+});

--- a/src/components/PlayerPlate/Me/PlayerPlateMe.tsx
+++ b/src/components/PlayerPlate/Me/PlayerPlateMe.tsx
@@ -1,3 +1,4 @@
+import { Avatar } from "components/Avatar/Avatar";
 import { Button } from "components/Button/Button";
 import React from "react";
 import { Badge } from "../components/Badge/Badge";
@@ -22,6 +23,7 @@ type Props = {
 
 export const PlayerPlateMe: React.FC<Props> = ({
   userName,
+  userPhoto,
   badge,
   color,
   status,
@@ -35,7 +37,13 @@ export const PlayerPlateMe: React.FC<Props> = ({
       status={status}
       viewAlgo={true}
       size="L"
-      playerIcon={<div>avatar</div>}
+      playerIcon={
+        <Avatar
+          userPhotoUrl={userPhoto}
+          type="user"
+          color={color === "magenta" ? "pink" : color}
+        />
+      }
       columnTop={
         <ColumnTopStye>
           <span className="playerplateme-name">{userName}</span>

--- a/src/components/PlayerPlate/Me/PlayerPlateMe.tsx
+++ b/src/components/PlayerPlate/Me/PlayerPlateMe.tsx
@@ -1,0 +1,86 @@
+import { Button } from "components/Button/Button";
+import React from "react";
+import { Badge } from "../components/Badge/Badge";
+import { PlayerPlateCard } from "../components/PlayerPlateCard/PlayerPlateCard";
+import { Status } from "../components/Status/Status";
+import {
+  ColumnBottomStye,
+  ColumnMiddleStye,
+  ColumnTopStye,
+} from "./PlayerPlateMeStyle";
+
+type Props = {
+  userName?: string;
+  userPhoto?: string;
+  badge?: string;
+  color?: "turquoise" | "leaf" | "orange" | "magenta";
+  status: "default" | "ready";
+  selectedCodeName?: string;
+  onClickSelectCode?: () => void;
+  onClickSelectOtherCode?: () => void;
+};
+
+export const PlayerPlateMe: React.FC<Props> = ({
+  userName,
+  badge,
+  color,
+  status,
+  selectedCodeName,
+  onClickSelectCode,
+  onClickSelectOtherCode,
+}) => {
+  return (
+    <PlayerPlateCard
+      color={color}
+      status={status}
+      viewAlgo={true}
+      size="L"
+      playerIcon={<div>avatar</div>}
+      columnTop={
+        <ColumnTopStye>
+          <span className="playerplateme-name">{userName}</span>
+          <Badge badgeName={badge} color={color} />
+        </ColumnTopStye>
+      }
+      columnMiddle={
+        <ColumnMiddleStye>
+          {status === "default" ? (
+            <Button
+              color="blue"
+              size="L"
+              value="コードを選ぶ"
+              onClick={onClickSelectCode}
+            />
+          ) : (
+            <>
+              <Button
+                color="white"
+                size="M"
+                value="別のコードを選ぶ"
+                onClick={onClickSelectOtherCode}
+              />
+              <span className="playerplateme-codename">{selectedCodeName}</span>
+            </>
+          )}
+        </ColumnMiddleStye>
+      }
+      columnBottom={
+        <ColumnBottomStye>
+          {status === "default" ? (
+            <Status
+              statusMessage="コード未選択"
+              viewCheckMark={false}
+              color={color}
+            />
+          ) : (
+            <Status
+              statusMessage="準備完了"
+              viewCheckMark={true}
+              color={color}
+            />
+          )}
+        </ColumnBottomStye>
+      }
+    />
+  );
+};

--- a/src/components/PlayerPlate/Me/PlayerPlateMeStyle.tsx
+++ b/src/components/PlayerPlate/Me/PlayerPlateMeStyle.tsx
@@ -1,0 +1,42 @@
+import styled from "styled-components";
+import { FONT_WEIGHT } from "styles/constants/constants";
+import { FlexGap } from "styles/FlexGap/FlexGap";
+import { PlayerPlateColors } from "../colors";
+
+export const ColumnTopStye = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-bottom: 24px;
+  ${FlexGap({ gap: "4px", direction: "column" })}
+
+  .playerplateme-name {
+    font-weight: ${FONT_WEIGHT.BOLD};
+    font-size: 30px;
+    line-height: 43px;
+    transform: matrix(1, 0, -0.08, 1, 0, 0);
+  }
+`;
+
+export const ColumnMiddleStye = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: stretch;
+  padding-bottom: 16px;
+  ${FlexGap({ gap: "16px", direction: "column" })}
+
+  width: 100%;
+  height: 164px;
+  flex-grow: 0;
+
+  .playerplateme-codename {
+    font-weight: ${FONT_WEIGHT.BOLD};
+    font-size: 18px;
+    line-height: 150%;
+    color: ${PlayerPlateColors.badge};
+    text-align: center;
+  }
+`;
+
+export const ColumnBottomStye = styled.div``;

--- a/src/components/PlayerPlate/Me/__snapshots__/PlayerPlateMe.test.tsx.snap
+++ b/src/components/PlayerPlate/Me/__snapshots__/PlayerPlateMe.test.tsx.snap
@@ -1,0 +1,404 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PlayerPlateMe /> snapshot test 1`] = `
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-weight: 700;
+  line-height: 150%;
+  color: #FFFFFF;
+  background: #5E58C7;
+  border-radius: 24px;
+  padding-bottom: 8px;
+  font-size: 24px;
+}
+
+.c7 .frame {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+}
+
+.c7 .frame {
+  background: linear-gradient(270deg,#4462FF 0%,#5F57FF 48.44%,#9670FF 100%);
+}
+
+.c7 .frame {
+  border-radius: 24px;
+  padding: 24px 64px;
+  gap: 10px;
+}
+
+.c5 {
+  width: 19px;
+  height: 19px;
+  fill: #34C5D5;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 16px;
+}
+
+.c4 .badge_name {
+  -webkit-transform: matrix(1,0,-0.08,1,0,0);
+  -ms-transform: matrix(1,0,-0.08,1,0,0);
+  transform: matrix(1,0,-0.08,1,0,0);
+  color: #4A5373;
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 20px;
+  text-align: center;
+}
+
+.c2 .algo_color_main {
+  fill: #34C5D5;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 32px;
+  gap: 16px;
+  position: relative;
+  border-radius: 48px;
+  background-color: #FAFAFA;
+  width: 432px;
+  height: 588px;
+}
+
+.c0 .playerplatecard_playericon {
+  position: absolute;
+  top: 30px;
+  left: 30px;
+}
+
+.c0 .playerplatecard_window {
+  position: relative;
+  border-radius: 24px;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+}
+
+.c0 .playerplatecard_window .c1 {
+  position: absolute;
+  bottom: -48px;
+  left: 50%;
+  -webkit-transform: translateX(-50%);
+  -ms-transform: translateX(-50%);
+  transform: translateX(-50%);
+}
+
+.c0 .playerplatecard_column_top,
+.c0 .playerplatecard_column_middle,
+.c0 .playerplatecard_column_bottom {
+  width: 100%;
+}
+
+.c0 .playerplatecard_column_top,
+.c0 .playerplatecard_column_middle {
+  border-bottom: 1px solid #D7DAE4;
+}
+
+.c0 .playerplatecard_border {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  border: 1px solid #D7DAE4;
+  border-radius: 48px;
+}
+
+.c0 .playerplatecard_window {
+  background-color: #A7ECF1;
+}
+
+.c0 .playerplatecard_border {
+  border-color: #34C5D5;
+}
+
+.c0 .playerplatecard_border {
+  border-color: #D7DAE4;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 16px;
+}
+
+.c8 .playerplate-status-message {
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 35px;
+  color: #242A3D;
+  -webkit-transform: matrix(1,0,-0.08,1,0,0);
+  -ms-transform: matrix(1,0,-0.08,1,0,0);
+  transform: matrix(1,0,-0.08,1,0,0);
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding-bottom: 24px;
+  gap: 4px;
+}
+
+.c3 .playerplateme-name {
+  font-weight: 700;
+  font-size: 30px;
+  line-height: 43px;
+  -webkit-transform: matrix(1,0,-0.08,1,0,0);
+  -ms-transform: matrix(1,0,-0.08,1,0,0);
+  transform: matrix(1,0,-0.08,1,0,0);
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  padding-bottom: 16px;
+  gap: 16px;
+  width: 100%;
+  height: 164px;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+}
+
+.c6 .playerplateme-codename {
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 150%;
+  color: #4A5373;
+  text-align: center;
+}
+
+@supports not (gap:10px) {
+  .c7 .frame > *:not(:first-child) {
+    margin-top: 10px;
+  }
+}
+
+@supports not (gap:16px) {
+  .c4 > *:not(:first-child) {
+    margin-left: 16px;
+  }
+}
+
+@supports not (gap:16px) {
+  .c0 > *:not(:first-child) {
+    margin-top: 16px;
+  }
+}
+
+@supports not (gap:16px) {
+  .c8 > *:not(:first-child) {
+    margin-left: 16px;
+  }
+}
+
+@supports not (gap:4px) {
+  .c3 > *:not(:first-child) {
+    margin-top: 4px;
+  }
+}
+
+@supports not (gap:16px) {
+  .c6 > *:not(:first-child) {
+    margin-top: 16px;
+  }
+}
+
+<div
+  class="c0"
+  color="turquoise"
+>
+  <div
+    class="playerplatecard_window"
+  >
+    <div
+      class="c1 c2"
+      color="turquoise"
+    />
+  </div>
+  <div
+    class="playerplatecard_column_top"
+  >
+    <div
+      class="c3"
+    >
+      <span
+        class="playerplateme-name"
+      >
+        ほげ太郎
+      </span>
+      <div
+        class="c4"
+      >
+        <svg
+          class="c5"
+          color="turquoise"
+          height="19px"
+          width="19px"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+        <span
+          class="badge_name"
+        >
+          宇宙の探究者
+        </span>
+        <svg
+          class="c5"
+          color="turquoise"
+          height="19px"
+          width="19px"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    class="playerplatecard_column_middle"
+  >
+    <div
+      class="c6"
+    >
+      <button
+        class="c7"
+        color="blue"
+      >
+        <div
+          class="frame"
+        >
+          <span>
+            コードを選ぶ
+          </span>
+        </div>
+      </button>
+    </div>
+  </div>
+  <div
+    class="playerplatecard_column_bottom"
+  >
+    <div
+      class=""
+    >
+      <div
+        class="c8"
+        color="turquoise"
+      >
+        <span
+          class="playerplate-status-message"
+        >
+          コード未選択
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="playerplatecard_playericon"
+  >
+    <div>
+      avatar
+    </div>
+  </div>
+  <div
+    class="playerplatecard_border"
+  />
+</div>
+`;

--- a/src/components/PlayerPlate/Me/__snapshots__/PlayerPlateMe.test.tsx.snap
+++ b/src/components/PlayerPlate/Me/__snapshots__/PlayerPlateMe.test.tsx.snap
@@ -1,6 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<PlayerPlateMe /> snapshot test 1`] = `
+.c9 {
+  display: block;
+  width: 54px;
+  height: 54px;
+  border-radius: 50%;
+  border: 3px solid #FFFFFF;
+  background-color: #EAEBF1;
+  background-size: cover;
+  overflow: hidden;
+  position: relative;
+  border-color: #6CDBE5;
+  background-color: #ECFDFF;
+  background-image: url(/logo512.png);
+}
+
 .c7 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -393,9 +408,11 @@ exports[`<PlayerPlateMe /> snapshot test 1`] = `
   <div
     class="playerplatecard_playericon"
   >
-    <div>
-      avatar
-    </div>
+    <div
+      class="c9"
+      color="turquoise"
+      type="user"
+    />
   </div>
   <div
     class="playerplatecard_border"

--- a/src/components/PlayerPlate/Other/PlayerPlateOther.stories.tsx
+++ b/src/components/PlayerPlate/Other/PlayerPlateOther.stories.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { PlayerPlateOther } from "./PlayerPlateOther";
+
+export default {
+  title: "components/PlayerPlate/PlayerPlateOther",
+  component: PlayerPlateOther,
+} as ComponentMeta<typeof PlayerPlateOther>;
+
+const Template: ComponentStory<typeof PlayerPlateOther> = (args) => (
+  <PlayerPlateOther {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  userName: "ふが次郎",
+  userPhoto: "/logo512.png",
+  badge: "しがないプログラマ",
+  color: "turquoise",
+  status: "default",
+};
+
+export const OrangeReady = Template.bind({});
+OrangeReady.args = {
+  ...Default.args,
+  color: "orange",
+  status: "ready",
+};
+
+export const LeafDisconnecting = Template.bind({});
+LeafDisconnecting.args = {
+  ...Default.args,
+  color: "leaf",
+  status: "disconnecting",
+};
+
+export const MagentaBot = Template.bind({});
+MagentaBot.args = {
+  ...Default.args,
+  color: "magenta",
+  status: "bot",
+};
+
+export const TurquoiseWaiting = Template.bind({});
+TurquoiseWaiting.args = {
+  ...Default.args,
+  color: "turquoise",
+  status: "waiting",
+};

--- a/src/components/PlayerPlate/Other/PlayerPlateOther.stories.tsx
+++ b/src/components/PlayerPlate/Other/PlayerPlateOther.stories.tsx
@@ -15,6 +15,7 @@ const Template: ComponentStory<typeof PlayerPlateOther> = (args) => (
 export const Default = Template.bind({});
 Default.args = {
   userName: "ふが次郎",
+  userType: "user",
   userPhoto: "/logo512.png",
   badge: "しがないプログラマ",
   color: "turquoise",

--- a/src/components/PlayerPlate/Other/PlayerPlateOther.test.tsx
+++ b/src/components/PlayerPlate/Other/PlayerPlateOther.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { PlayerPlateOther } from "./PlayerPlateOther";
+import "jest-styled-components";
+import { render } from "enzyme";
+
+describe("<PlayerPlateOther />", () => {
+  const defaultProps = {
+    userName: "ふが次郎",
+    userPhoto: "/logo512.png",
+    badge: "しがないプログラマ",
+    color: "turquoise",
+    status: "default",
+  } as const;
+
+  it("snapshot test", () => {
+    const wrapper = render(<PlayerPlateOther {...defaultProps} />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("render test turquoise default", () => {
+    expect(
+      render(
+        <PlayerPlateOther
+          {...defaultProps}
+          color="turquoise"
+          status="default"
+        />
+      )
+    ).toBeTruthy();
+  });
+
+  it("render test orange ready", () => {
+    expect(
+      render(
+        <PlayerPlateOther {...defaultProps} color="orange" status="ready" />
+      )
+    ).toBeTruthy();
+  });
+
+  it("render test leaf", () => {
+    expect(
+      render(<PlayerPlateOther {...defaultProps} color="leaf" />)
+    ).toBeTruthy();
+  });
+
+  it("render test magenta", () => {
+    expect(
+      render(<PlayerPlateOther {...defaultProps} color="magenta" />)
+    ).toBeTruthy();
+  });
+});

--- a/src/components/PlayerPlate/Other/PlayerPlateOther.test.tsx
+++ b/src/components/PlayerPlate/Other/PlayerPlateOther.test.tsx
@@ -6,6 +6,7 @@ import { render } from "enzyme";
 describe("<PlayerPlateOther />", () => {
   const defaultProps = {
     userName: "ふが次郎",
+    userType: "user",
     userPhoto: "/logo512.png",
     badge: "しがないプログラマ",
     color: "turquoise",

--- a/src/components/PlayerPlate/Other/PlayerPlateOther.tsx
+++ b/src/components/PlayerPlate/Other/PlayerPlateOther.tsx
@@ -1,3 +1,4 @@
+import { Avatar } from "components/Avatar/Avatar";
 import { Button } from "components/Button/Button";
 import React from "react";
 import { Badge } from "../components/Badge/Badge";
@@ -7,6 +8,7 @@ import { ColumnBottomStye, ColumnTopStye } from "./PlayerPlateOtherStyle";
 
 type Props = {
   userName?: string;
+  userType?: "user" | "anonymous";
   userPhoto?: string;
   badge?: string;
   color?: "turquoise" | "leaf" | "orange" | "magenta";
@@ -16,6 +18,8 @@ type Props = {
 
 export const PlayerPlateOther: React.FC<Props> = ({
   userName,
+  userType,
+  userPhoto,
   badge,
   color,
   status,
@@ -27,7 +31,29 @@ export const PlayerPlateOther: React.FC<Props> = ({
       status={status}
       viewAlgo={status === "default" || status === "ready" || status === "bot"}
       size="M"
-      playerIcon={<div>avatar</div>}
+      playerIcon={
+        status === "bot" ? undefined : (
+          <Avatar
+            userPhotoUrl={userPhoto}
+            type={
+              status === "disconnecting"
+                ? "anonymous"
+                : status === "waiting"
+                ? "anonymous"
+                : userType || "anonymous"
+            }
+            color={
+              status === "disconnecting"
+                ? "gray"
+                : status === "waiting"
+                ? "gray"
+                : color === "magenta"
+                ? "pink"
+                : color
+            }
+          />
+        )
+      }
       columnTop={
         <ColumnTopStye waiting={status === "waiting"}>
           {status === "waiting" ? (

--- a/src/components/PlayerPlate/Other/PlayerPlateOther.tsx
+++ b/src/components/PlayerPlate/Other/PlayerPlateOther.tsx
@@ -1,0 +1,85 @@
+import { Button } from "components/Button/Button";
+import React from "react";
+import { Badge } from "../components/Badge/Badge";
+import { PlayerPlateCard } from "../components/PlayerPlateCard/PlayerPlateCard";
+import { Status } from "../components/Status/Status";
+import { ColumnBottomStye, ColumnTopStye } from "./PlayerPlateOtherStyle";
+
+type Props = {
+  userName?: string;
+  userPhoto?: string;
+  badge?: string;
+  color?: "turquoise" | "leaf" | "orange" | "magenta";
+  status: "default" | "ready" | "disconnecting" | "bot" | "waiting";
+  onClickChangeCPU?: () => void;
+};
+
+export const PlayerPlateOther: React.FC<Props> = ({
+  userName,
+  badge,
+  color,
+  status,
+  onClickChangeCPU,
+}) => {
+  return (
+    <PlayerPlateCard
+      color={color}
+      status={status}
+      viewAlgo={status === "default" || status === "ready" || status === "bot"}
+      size="M"
+      playerIcon={<div>avatar</div>}
+      columnTop={
+        <ColumnTopStye waiting={status === "waiting"}>
+          {status === "waiting" ? (
+            <Button
+              color="white"
+              size="S"
+              value="コンピュータにする"
+              onClick={onClickChangeCPU}
+            />
+          ) : (
+            <>
+              <span className="playerplateme-name">{userName}</span>
+              <Badge badgeName={badge} color={color} />
+            </>
+          )}
+        </ColumnTopStye>
+      }
+      columnBottom={
+        <ColumnBottomStye>
+          {status === "default" ? (
+            <Status
+              statusMessage="コード未選択"
+              viewCheckMark={false}
+              color={color}
+            />
+          ) : status === "ready" ? (
+            <Status
+              statusMessage="準備完了"
+              viewCheckMark={true}
+              color={color}
+            />
+          ) : status === "disconnecting" ? (
+            <Status
+              statusMessage="切断中…"
+              viewCheckMark={false}
+              color={color}
+            />
+          ) : status === "bot" ? (
+            <Status
+              statusMessage="準備完了"
+              viewCheckMark={true}
+              color={color}
+            />
+          ) : (
+            <Status
+              statusMessage="待機中…"
+              viewCheckMark={false}
+              color={color}
+            />
+          )}
+        </ColumnBottomStye>
+      }
+    />
+  );
+};

--- a/src/components/PlayerPlate/Other/PlayerPlateOtherStyle.tsx
+++ b/src/components/PlayerPlate/Other/PlayerPlateOtherStyle.tsx
@@ -1,0 +1,26 @@
+import styled from "styled-components";
+import { FONT_WEIGHT } from "styles/constants/constants";
+import { FlexGap } from "styles/FlexGap/FlexGap";
+
+type ColumnTopProps = {
+  waiting: boolean;
+};
+
+export const ColumnTopStye = styled.div<ColumnTopProps>`
+  display: flex;
+  flex-direction: column;
+  justify-content: ${({ waiting }) => (waiting ? "center" : "flex-start")};
+  align-items: center;
+  padding-bottom: ${({ waiting }) => (waiting ? "24px" : "16px")};
+  height: 90.78px;
+  ${FlexGap({ gap: "4px", direction: "column" })}
+
+  .playerplateme-name {
+    font-weight: ${FONT_WEIGHT.BOLD};
+    font-size: 30px;
+    line-height: 43px;
+    transform: matrix(1, 0, -0.08, 1, 0, 0);
+  }
+`;
+
+export const ColumnBottomStye = styled.div``;

--- a/src/components/PlayerPlate/Other/__snapshots__/PlayerPlateOther.test.tsx.snap
+++ b/src/components/PlayerPlate/Other/__snapshots__/PlayerPlateOther.test.tsx.snap
@@ -1,6 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<PlayerPlateOther /> snapshot test 1`] = `
+.c7 {
+  display: block;
+  width: 54px;
+  height: 54px;
+  border-radius: 50%;
+  border: 3px solid #FFFFFF;
+  background-color: #EAEBF1;
+  background-size: cover;
+  overflow: hidden;
+  position: relative;
+  border-color: #6CDBE5;
+  background-color: #ECFDFF;
+  background-image: url(/logo512.png);
+}
+
 .c5 {
   width: 19px;
   height: 19px;
@@ -278,9 +293,11 @@ exports[`<PlayerPlateOther /> snapshot test 1`] = `
   <div
     class="playerplatecard_playericon"
   >
-    <div>
-      avatar
-    </div>
+    <div
+      class="c7"
+      color="turquoise"
+      type="user"
+    />
   </div>
   <div
     class="playerplatecard_border"

--- a/src/components/PlayerPlate/Other/__snapshots__/PlayerPlateOther.test.tsx.snap
+++ b/src/components/PlayerPlate/Other/__snapshots__/PlayerPlateOther.test.tsx.snap
@@ -1,0 +1,289 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PlayerPlateOther /> snapshot test 1`] = `
+.c5 {
+  width: 19px;
+  height: 19px;
+  fill: #34C5D5;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 16px;
+}
+
+.c4 .badge_name {
+  -webkit-transform: matrix(1,0,-0.08,1,0,0);
+  -ms-transform: matrix(1,0,-0.08,1,0,0);
+  transform: matrix(1,0,-0.08,1,0,0);
+  color: #4A5373;
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 20px;
+  text-align: center;
+}
+
+.c2 .algo_color_main {
+  fill: #34C5D5;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 32px;
+  gap: 16px;
+  position: relative;
+  border-radius: 48px;
+  background-color: #FAFAFA;
+  width: 320px;
+  height: 408px;
+}
+
+.c0 .playerplatecard_playericon {
+  position: absolute;
+  top: 30px;
+  left: 30px;
+}
+
+.c0 .playerplatecard_window {
+  position: relative;
+  border-radius: 24px;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+}
+
+.c0 .playerplatecard_window .c1 {
+  position: absolute;
+  bottom: -48px;
+  left: 50%;
+  -webkit-transform: translateX(-50%);
+  -ms-transform: translateX(-50%);
+  transform: translateX(-50%);
+}
+
+.c0 .playerplatecard_column_top,
+.c0 .playerplatecard_column_middle,
+.c0 .playerplatecard_column_bottom {
+  width: 100%;
+}
+
+.c0 .playerplatecard_column_top,
+.c0 .playerplatecard_column_middle {
+  border-bottom: 1px solid #D7DAE4;
+}
+
+.c0 .playerplatecard_border {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  border: 1px solid #D7DAE4;
+  border-radius: 48px;
+}
+
+.c0 .playerplatecard_window {
+  background-color: #A7ECF1;
+}
+
+.c0 .playerplatecard_border {
+  border-color: #34C5D5;
+}
+
+.c0 .playerplatecard_border {
+  border-color: #D7DAE4;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 16px;
+}
+
+.c6 .playerplate-status-message {
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 35px;
+  color: #242A3D;
+  -webkit-transform: matrix(1,0,-0.08,1,0,0);
+  -ms-transform: matrix(1,0,-0.08,1,0,0);
+  transform: matrix(1,0,-0.08,1,0,0);
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding-bottom: 16px;
+  height: 90.78px;
+  gap: 4px;
+}
+
+.c3 .playerplateme-name {
+  font-weight: 700;
+  font-size: 30px;
+  line-height: 43px;
+  -webkit-transform: matrix(1,0,-0.08,1,0,0);
+  -ms-transform: matrix(1,0,-0.08,1,0,0);
+  transform: matrix(1,0,-0.08,1,0,0);
+}
+
+@supports not (gap:16px) {
+  .c4 > *:not(:first-child) {
+    margin-left: 16px;
+  }
+}
+
+@supports not (gap:16px) {
+  .c0 > *:not(:first-child) {
+    margin-top: 16px;
+  }
+}
+
+@supports not (gap:16px) {
+  .c6 > *:not(:first-child) {
+    margin-left: 16px;
+  }
+}
+
+@supports not (gap:4px) {
+  .c3 > *:not(:first-child) {
+    margin-top: 4px;
+  }
+}
+
+<div
+  class="c0"
+  color="turquoise"
+>
+  <div
+    class="playerplatecard_window"
+  >
+    <div
+      class="c1 c2"
+      color="turquoise"
+    />
+  </div>
+  <div
+    class="playerplatecard_column_top"
+  >
+    <div
+      class="c3"
+    >
+      <span
+        class="playerplateme-name"
+      >
+        ふが次郎
+      </span>
+      <div
+        class="c4"
+      >
+        <svg
+          class="c5"
+          color="turquoise"
+          height="19px"
+          width="19px"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+        <span
+          class="badge_name"
+        >
+          しがないプログラマ
+        </span>
+        <svg
+          class="c5"
+          color="turquoise"
+          height="19px"
+          width="19px"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    class="playerplatecard_column_bottom"
+  >
+    <div
+      class=""
+    >
+      <div
+        class="c6"
+        color="turquoise"
+      >
+        <span
+          class="playerplate-status-message"
+        >
+          コード未選択
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="playerplatecard_playericon"
+  >
+    <div>
+      avatar
+    </div>
+  </div>
+  <div
+    class="playerplatecard_border"
+  />
+</div>
+`;

--- a/src/components/PlayerPlate/colors.ts
+++ b/src/components/PlayerPlate/colors.ts
@@ -1,0 +1,38 @@
+import {
+  GRAY_00,
+  GRAY_30,
+  GRAY_80,
+  LEAF_30,
+  LEAF_50,
+  ORANGE_30,
+  ORANGE_50,
+  PINK_30,
+  PINK_50,
+  TURQUOISE_30,
+  TURQUOISE_50,
+} from "styles/colors";
+
+export const PlayerPlateColors = {
+  background: GRAY_00,
+  border: GRAY_30,
+  turquoise: {
+    main: TURQUOISE_50,
+    back: TURQUOISE_30,
+  },
+  orange: {
+    main: ORANGE_50,
+    back: ORANGE_30,
+  },
+  leaf: {
+    main: LEAF_50,
+    back: LEAF_30,
+  },
+  magenta: {
+    main: PINK_50,
+    back: PINK_30,
+  },
+  gray: {
+    back: GRAY_30,
+  },
+  badge: GRAY_80,
+};

--- a/src/components/PlayerPlate/components/Badge/Badge.stories.tsx
+++ b/src/components/PlayerPlate/components/Badge/Badge.stories.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { Badge } from "./Badge";
+
+export default {
+  title: "components/PlayerPlate/Badge",
+  component: Badge,
+} as ComponentMeta<typeof Badge>;
+
+const Template: ComponentStory<typeof Badge> = (args) => <Badge {...args} />;
+
+export const Turquoise = Template.bind({});
+Turquoise.args = {
+  badgeName: "宇宙の探究者",
+  color: "turquoise",
+};
+
+export const Leaf = Template.bind({});
+Leaf.args = {
+  badgeName: "宇宙の探究者",
+  color: "leaf",
+};
+
+export const Orange = Template.bind({});
+Orange.args = {
+  badgeName: "宇宙の探究者",
+  color: "orange",
+};
+
+export const Magenta = Template.bind({});
+Magenta.args = {
+  badgeName: "宇宙の探究者",
+  color: "magenta",
+};

--- a/src/components/PlayerPlate/components/Badge/Badge.test.tsx
+++ b/src/components/PlayerPlate/components/Badge/Badge.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Badge } from "./Badge";
+import "jest-styled-components";
+import { render } from "enzyme";
+
+describe("<Badge />", () => {
+  it("snapshot test", () => {
+    const wrapper = render(<Badge />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("render test turquoise", () => {
+    expect(
+      render(<Badge badgeName="宇宙の探究者" color="turquoise" />)
+    ).toBeTruthy();
+  });
+
+  it("render test leaf", () => {
+    expect(
+      render(<Badge badgeName="宇宙の探究者" color="leaf" />)
+    ).toBeTruthy();
+  });
+
+  it("render test orange", () => {
+    expect(
+      render(<Badge badgeName="宇宙の探究者" color="orange" />)
+    ).toBeTruthy();
+  });
+
+  it("render test magenta", () => {
+    expect(
+      render(<Badge badgeName="宇宙の探究者" color="magenta" />)
+    ).toBeTruthy();
+  });
+});

--- a/src/components/PlayerPlate/components/Badge/Badge.tsx
+++ b/src/components/PlayerPlate/components/Badge/Badge.tsx
@@ -1,0 +1,18 @@
+import { Star } from "components/Star/Star";
+import React from "react";
+import { BadgeStyle, BadgeStyleProps } from "./BadgeStyle";
+
+type Props = BadgeStyleProps & {
+  badgeName?: string;
+  color?: "turquoise" | "leaf" | "orange" | "magenta";
+};
+
+export const Badge: React.FC<Props> = ({ badgeName, color, ...styleProps }) => {
+  return (
+    <BadgeStyle {...styleProps}>
+      <Star color={color} width="19px" height="19px" />
+      <span className="badge_name">{badgeName || "称号なし"}</span>
+      <Star color={color} width="19px" height="19px" />
+    </BadgeStyle>
+  );
+};

--- a/src/components/PlayerPlate/components/Badge/BadgeStyle.tsx
+++ b/src/components/PlayerPlate/components/Badge/BadgeStyle.tsx
@@ -1,0 +1,28 @@
+import styled, { css } from "styled-components";
+import { FONT_WEIGHT } from "styles/constants/constants";
+import { PlayerPlateColors } from "components/PlayerPlate/colors";
+import { FlexGap } from "styles/FlexGap/FlexGap";
+
+export type BadgeStyleProps = {};
+
+const defaultStyle = css`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  ${FlexGap({ gap: "16px", direction: "row" })}
+
+  .badge_name {
+    transform: matrix(1, 0, -0.08, 1, 0, 0);
+    color: ${PlayerPlateColors.badge};
+    font-weight: ${FONT_WEIGHT.BOLD};
+    font-size: 14px;
+    line-height: 20px;
+    text-align: center;
+  }
+`;
+
+export const BadgeStyle = styled.div<BadgeStyleProps>`
+  ${defaultStyle}
+`;
+
+BadgeStyle.defaultProps = {};

--- a/src/components/PlayerPlate/components/Badge/__snapshots__/Badge.test.tsx.snap
+++ b/src/components/PlayerPlate/components/Badge/__snapshots__/Badge.test.tsx.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Badge /> snapshot test 1`] = `
+.c1 {
+  width: 19px;
+  height: 19px;
+  fill: #F8919F;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 16px;
+}
+
+.c0 .badge_name {
+  -webkit-transform: matrix(1,0,-0.08,1,0,0);
+  -ms-transform: matrix(1,0,-0.08,1,0,0);
+  transform: matrix(1,0,-0.08,1,0,0);
+  color: #4A5373;
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 20px;
+  text-align: center;
+}
+
+@supports not (gap:16px) {
+  .c0 > *:not(:first-child) {
+    margin-left: 16px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <svg
+    class="c1"
+    color="pink"
+    height="19px"
+    width="19px"
+    xlink="http://www.w3.org/1999/xlink"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  <span
+    class="badge_name"
+  >
+    称号なし
+  </span>
+  <svg
+    class="c1"
+    color="pink"
+    height="19px"
+    width="19px"
+    xlink="http://www.w3.org/1999/xlink"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</div>
+`;

--- a/src/components/PlayerPlate/components/PlayerPlateCard/PlayerPlateCard.stories.tsx
+++ b/src/components/PlayerPlate/components/PlayerPlateCard/PlayerPlateCard.stories.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { PlayerPlateCard } from "./PlayerPlateCard";
+
+export default {
+  title: "components/PlayerPlate/PlayerPlateCard",
+  component: PlayerPlateCard,
+} as ComponentMeta<typeof PlayerPlateCard>;
+
+const Template: ComponentStory<typeof PlayerPlateCard> = (args) => (
+  <PlayerPlateCard {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  playerIcon: <>icon</>,
+  viewAlgo: true,
+  columnTop: <>top</>,
+  columnMiddle: <>middle</>,
+  columnBottom: <>bottom</>,
+};

--- a/src/components/PlayerPlate/components/PlayerPlateCard/PlayerPlateCard.test.tsx
+++ b/src/components/PlayerPlate/components/PlayerPlateCard/PlayerPlateCard.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { PlayerPlateCard } from "./PlayerPlateCard";
+import "jest-styled-components";
+import { render } from "enzyme";
+
+describe("<PlayerPlateCard />", () => {
+  it("snapshot test", () => {
+    const wrapper = render(
+      <PlayerPlateCard
+        playerIcon={<>icon</>}
+        viewAlgo={true}
+        columnTop={<>top</>}
+        columnMiddle={<>middle</>}
+        columnBottom={<>bottom</>}
+      />
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/PlayerPlate/components/PlayerPlateCard/PlayerPlateCard.tsx
+++ b/src/components/PlayerPlate/components/PlayerPlateCard/PlayerPlateCard.tsx
@@ -1,0 +1,40 @@
+import { Algo } from "components/Character/Algo/Algo";
+import React, { ReactElement } from "react";
+import {
+  PlayerPlateCardStyle,
+  PlayerPlateCardStyleProps,
+} from "./PlayerPlateCardStyle";
+
+type Props = PlayerPlateCardStyleProps & {
+  playerIcon: ReactElement;
+  viewAlgo: boolean;
+  columnTop: ReactElement;
+  columnMiddle?: ReactElement;
+  columnBottom: ReactElement;
+};
+
+export const PlayerPlateCard: React.FC<Props> = ({
+  playerIcon,
+  viewAlgo,
+  columnTop,
+  columnMiddle,
+  columnBottom,
+  ...styleProps
+}) => {
+  return (
+    <PlayerPlateCardStyle {...styleProps}>
+      <div className="playerplatecard_window">
+        {viewAlgo && <Algo color={styleProps.color} />}
+      </div>
+      <div className="playerplatecard_column_top">{columnTop}</div>
+      {columnMiddle && (
+        <div className="playerplatecard_column_middle">{columnMiddle}</div>
+      )}
+      <div className="playerplatecard_column_bottom">{columnBottom}</div>
+
+      {/* absolute要素 */}
+      <div className="playerplatecard_playericon">{playerIcon}</div>
+      <div className="playerplatecard_border" />
+    </PlayerPlateCardStyle>
+  );
+};

--- a/src/components/PlayerPlate/components/PlayerPlateCard/PlayerPlateCard.tsx
+++ b/src/components/PlayerPlate/components/PlayerPlateCard/PlayerPlateCard.tsx
@@ -6,7 +6,7 @@ import {
 } from "./PlayerPlateCardStyle";
 
 type Props = PlayerPlateCardStyleProps & {
-  playerIcon: ReactElement;
+  playerIcon?: ReactElement;
   viewAlgo: boolean;
   columnTop: ReactElement;
   columnMiddle?: ReactElement;
@@ -33,7 +33,9 @@ export const PlayerPlateCard: React.FC<Props> = ({
       <div className="playerplatecard_column_bottom">{columnBottom}</div>
 
       {/* absolute要素 */}
-      <div className="playerplatecard_playericon">{playerIcon}</div>
+      {playerIcon && (
+        <div className="playerplatecard_playericon">{playerIcon}</div>
+      )}
       <div className="playerplatecard_border" />
     </PlayerPlateCardStyle>
   );

--- a/src/components/PlayerPlate/components/PlayerPlateCard/PlayerPlateCardStyle.tsx
+++ b/src/components/PlayerPlate/components/PlayerPlateCard/PlayerPlateCardStyle.tsx
@@ -1,0 +1,188 @@
+import { AlgoStyle } from "components/Character/Algo/AlgoStyle";
+import { PlayerPlateColors } from "components/PlayerPlate/colors";
+import styled, { css } from "styled-components";
+import { FlexGap } from "styles/FlexGap/FlexGap";
+
+export type PlayerPlateCardStyleProps = {
+  color?: "turquoise" | "leaf" | "orange" | "magenta";
+  status?: "default" | "ready" | "disconnecting" | "bot" | "waiting";
+  size?: "L" | "M";
+};
+
+const defaultStyle = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 32px;
+  ${FlexGap({ gap: "16px", direction: "column" })}
+
+  position: relative;
+
+  border-radius: 48px;
+  background-color: ${PlayerPlateColors.background};
+
+  .playerplatecard_playericon {
+    position: absolute;
+    top: 30px;
+    left: 30px;
+  }
+
+  .playerplatecard_window {
+    position: relative;
+    border-radius: 24px;
+    align-self: stretch;
+    flex-grow: 1;
+    overflow: hidden;
+
+    ${AlgoStyle} {
+      position: absolute;
+      bottom: -48px;
+      left: 50%;
+      transform: translateX(-50%);
+    }
+  }
+
+  .playerplatecard_column_top,
+  .playerplatecard_column_middle,
+  .playerplatecard_column_bottom {
+    width: 100%;
+  }
+
+  .playerplatecard_column_top,
+  .playerplatecard_column_middle {
+    border-bottom: 1px solid ${PlayerPlateColors.border};
+  }
+
+  .playerplatecard_column_bottom {
+  }
+
+  .playerplatecard_border {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+
+    pointer-events: none;
+
+    border: 1px solid ${PlayerPlateColors.border};
+    border-radius: 48px;
+  }
+`;
+
+const turquoiseStyle = css`
+  .playerplatecard_window {
+    background-color: ${PlayerPlateColors.turquoise.back};
+  }
+
+  .playerplatecard_border {
+    border-color: ${PlayerPlateColors.turquoise.main};
+  }
+`;
+
+const leafStyle = css`
+  .playerplatecard_window {
+    background-color: ${PlayerPlateColors.leaf.back};
+  }
+
+  .playerplatecard_border {
+    border-color: ${PlayerPlateColors.leaf.main};
+  }
+`;
+
+const orangeStyle = css`
+  .playerplatecard_window {
+    background-color: ${PlayerPlateColors.orange.back};
+  }
+
+  .playerplatecard_border {
+    border-color: ${PlayerPlateColors.orange.main};
+  }
+`;
+
+const magentaStyle = css`
+  .playerplatecard_window {
+    background-color: ${PlayerPlateColors.magenta.back};
+  }
+
+  .playerplatecard_border {
+    border-color: ${PlayerPlateColors.magenta.main};
+  }
+`;
+
+const defaultBorderStyle = css`
+  .playerplatecard_border {
+    border-color: ${PlayerPlateColors.border};
+  }
+`;
+
+const readyStyle = css`
+  .playerplatecard_border {
+    border-width: 4px;
+  }
+`;
+
+const disconnectingStyle = css`
+  .playerplatecard_window {
+    background-color: ${PlayerPlateColors.gray.back};
+  }
+
+  .playerplatecard_border {
+    border-color: ${PlayerPlateColors.border};
+  }
+`;
+
+const botStyle = css`
+  .playerplatecard_window {
+    background-color: ${PlayerPlateColors.gray.back};
+  }
+
+  .playerplatecard_border {
+    border-width: 4px;
+  }
+`;
+
+const waitingStyle = css`
+  .playerplatecard_window {
+    background-color: ${PlayerPlateColors.gray.back};
+  }
+
+  .playerplatecard_border {
+    border-color: ${PlayerPlateColors.border};
+  }
+`;
+
+const lStyle = css`
+  width: 432px;
+  height: 588px;
+`;
+
+const mStyle = css`
+  width: 320px;
+  height: 408px;
+`;
+
+export const PlayerPlateCardStyle = styled.div<PlayerPlateCardStyleProps>`
+  ${defaultStyle}
+
+  ${({ color }) => color === "turquoise" && turquoiseStyle}
+  ${({ color }) => color === "leaf" && leafStyle}
+  ${({ color }) => color === "orange" && orangeStyle}
+  ${({ color }) => color === "magenta" && magentaStyle}
+
+  ${({ status }) => status === "default" && defaultBorderStyle}
+  ${({ status }) => status === "ready" && readyStyle}
+  ${({ status }) => status === "disconnecting" && disconnectingStyle}
+  ${({ status }) => status === "bot" && botStyle}
+  ${({ status }) => status === "waiting" && waitingStyle}
+
+  ${({ size }) => size === "L" && lStyle}
+  ${({ size }) => size === "M" && mStyle}
+`;
+
+PlayerPlateCardStyle.defaultProps = {
+  color: "turquoise",
+  status: "default",
+  size: "M",
+};

--- a/src/components/PlayerPlate/components/PlayerPlateCard/__snapshots__/PlayerPlateCard.test.tsx.snap
+++ b/src/components/PlayerPlate/components/PlayerPlateCard/__snapshots__/PlayerPlateCard.test.tsx.snap
@@ -1,0 +1,137 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PlayerPlateCard /> snapshot test 1`] = `
+.c2 .algo_color_main {
+  fill: #34C5D5;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 32px;
+  gap: 16px;
+  position: relative;
+  border-radius: 48px;
+  background-color: #FAFAFA;
+  width: 320px;
+  height: 408px;
+}
+
+.c0 .playerplatecard_playericon {
+  position: absolute;
+  top: 30px;
+  left: 30px;
+}
+
+.c0 .playerplatecard_window {
+  position: relative;
+  border-radius: 24px;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+}
+
+.c0 .playerplatecard_window .c1 {
+  position: absolute;
+  bottom: -48px;
+  left: 50%;
+  -webkit-transform: translateX(-50%);
+  -ms-transform: translateX(-50%);
+  transform: translateX(-50%);
+}
+
+.c0 .playerplatecard_column_top,
+.c0 .playerplatecard_column_middle,
+.c0 .playerplatecard_column_bottom {
+  width: 100%;
+}
+
+.c0 .playerplatecard_column_top,
+.c0 .playerplatecard_column_middle {
+  border-bottom: 1px solid #D7DAE4;
+}
+
+.c0 .playerplatecard_border {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  border: 1px solid #D7DAE4;
+  border-radius: 48px;
+}
+
+.c0 .playerplatecard_window {
+  background-color: #A7ECF1;
+}
+
+.c0 .playerplatecard_border {
+  border-color: #34C5D5;
+}
+
+.c0 .playerplatecard_border {
+  border-color: #D7DAE4;
+}
+
+@supports not (gap:16px) {
+  .c0 > *:not(:first-child) {
+    margin-top: 16px;
+  }
+}
+
+<div
+  class="c0"
+  color="turquoise"
+>
+  <div
+    class="playerplatecard_window"
+  >
+    <div
+      class="c1 c2"
+      color="turquoise"
+    />
+  </div>
+  <div
+    class="playerplatecard_column_top"
+  >
+    top
+  </div>
+  <div
+    class="playerplatecard_column_middle"
+  >
+    middle
+  </div>
+  <div
+    class="playerplatecard_column_bottom"
+  >
+    bottom
+  </div>
+  <div
+    class="playerplatecard_playericon"
+  >
+    icon
+  </div>
+  <div
+    class="playerplatecard_border"
+  />
+</div>
+`;

--- a/src/components/PlayerPlate/components/Status/Status.stories.tsx
+++ b/src/components/PlayerPlate/components/Status/Status.stories.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { Status } from "./Status";
+
+export default {
+  title: "components/PlayerPlate/Status",
+  component: Status,
+} as ComponentMeta<typeof Status>;
+
+const Template: ComponentStory<typeof Status> = (args) => <Status {...args} />;
+
+export const Checked = Template.bind({});
+Checked.args = {
+  statusMessage: "準備完了",
+  viewCheckMark: true,
+};
+
+export const Unchecked = Template.bind({});
+Unchecked.args = {
+  statusMessage: "準備中…",
+  viewCheckMark: false,
+};

--- a/src/components/PlayerPlate/components/Status/Status.test.tsx
+++ b/src/components/PlayerPlate/components/Status/Status.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Status } from "./Status";
+import "jest-styled-components";
+import { render } from "enzyme";
+
+describe("<Status />", () => {
+  it("snapshot test", () => {
+    const wrapper = render(
+      <Status statusMessage="message" viewCheckMark={true} />
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("render test turquoise", () => {
+    expect(
+      render(
+        <Status
+          statusMessage="message"
+          viewCheckMark={true}
+          color="turquoise"
+        />
+      )
+    ).toBeTruthy();
+  });
+
+  it("render test leaf", () => {
+    expect(
+      render(
+        <Status statusMessage="message" viewCheckMark={true} color="leaf" />
+      )
+    ).toBeTruthy();
+  });
+
+  it("render test orange", () => {
+    expect(
+      render(
+        <Status statusMessage="message" viewCheckMark={true} color="orange" />
+      )
+    ).toBeTruthy();
+  });
+
+  it("render test magenta", () => {
+    expect(
+      render(
+        <Status statusMessage="message" viewCheckMark={true} color="magenta" />
+      )
+    ).toBeTruthy();
+  });
+});

--- a/src/components/PlayerPlate/components/Status/Status.tsx
+++ b/src/components/PlayerPlate/components/Status/Status.tsx
@@ -1,0 +1,21 @@
+import { Checked } from "components/icons";
+import React from "react";
+import { CheckedIconProps, StatusStyle, StatusStyleProps } from "./StatusStyle";
+
+type Props = StatusStyleProps & {
+  statusMessage: string;
+  viewCheckMark: boolean;
+};
+
+export const Status: React.FC<Props> = ({
+  statusMessage,
+  viewCheckMark,
+  ...styleProps
+}) => {
+  return (
+    <StatusStyle viewCheckMark={viewCheckMark} {...styleProps}>
+      {viewCheckMark && <Checked {...CheckedIconProps(styleProps)} />}
+      <span className="playerplate-status-message">{statusMessage}</span>
+    </StatusStyle>
+  );
+};

--- a/src/components/PlayerPlate/components/Status/StatusStyle.tsx
+++ b/src/components/PlayerPlate/components/Status/StatusStyle.tsx
@@ -1,0 +1,65 @@
+import { Checked } from "components/icons";
+import { PlayerPlateColors } from "components/PlayerPlate/colors";
+import { ComponentProps } from "react";
+import styled, { css } from "styled-components";
+import { global } from "styles/colors";
+import { FONT_WEIGHT } from "styles/constants/constants";
+import { FlexGap } from "styles/FlexGap/FlexGap";
+
+export type StatusStyleProps = {
+  color?: "turquoise" | "leaf" | "orange" | "magenta";
+};
+
+type PrivateProps = {
+  viewCheckMark: boolean;
+};
+
+const defaultStyle = css`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  ${FlexGap({ gap: "16px", direction: "row" })}
+
+  .playerplate-status-message {
+    font-weight: ${FONT_WEIGHT.BOLD};
+    font-size: 24px;
+    line-height: 35px;
+    color: ${global.font};
+    transform: matrix(1, 0, -0.08, 1, 0, 0);
+  } ;
+`;
+
+const viewCheckMarkStyle = css`
+  padding-right: 8px;
+`;
+
+export const StatusStyle = styled.div<StatusStyleProps & PrivateProps>`
+  ${defaultStyle}
+
+  ${({ viewCheckMark }) => viewCheckMark && viewCheckMarkStyle}
+`;
+
+StatusStyle.defaultProps = {
+  color: "turquoise",
+};
+
+export const CheckedIconProps = ({
+  color,
+}: StatusStyleProps): ComponentProps<typeof Checked> => {
+  const fill =
+    color === "turquoise"
+      ? PlayerPlateColors.turquoise.main
+      : color === "leaf"
+      ? PlayerPlateColors.leaf.main
+      : color === "orange"
+      ? PlayerPlateColors.orange.main
+      : color === "magenta"
+      ? PlayerPlateColors.magenta.main
+      : PlayerPlateColors.turquoise.main;
+
+  return {
+    size: 32,
+    fill: fill,
+  };
+};

--- a/src/components/PlayerPlate/components/Status/__snapshots__/Status.test.tsx.snap
+++ b/src/components/PlayerPlate/components/Status/__snapshots__/Status.test.tsx.snap
@@ -1,0 +1,70 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Status /> snapshot test 1`] = `
+.c1 {
+  display: inline-block;
+  width: 32px;
+  height: 32px;
+  fill: #34C5D5;
+}
+
+.c1 > span,
+.c1 > div,
+.c1 > svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 16px;
+  padding-right: 8px;
+}
+
+.c0 .playerplate-status-message {
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 35px;
+  color: #242A3D;
+  -webkit-transform: matrix(1,0,-0.08,1,0,0);
+  -ms-transform: matrix(1,0,-0.08,1,0,0);
+  transform: matrix(1,0,-0.08,1,0,0);
+}
+
+@supports not (gap:16px) {
+  .c0 > *:not(:first-child) {
+    margin-left: 16px;
+  }
+}
+
+<div
+  class="c0"
+  color="turquoise"
+>
+  <span
+    class="c1"
+    display="inline-block"
+    fill="#34C5D5"
+  />
+  <span
+    class="playerplate-status-message"
+  >
+    message
+  </span>
+</div>
+`;

--- a/src/components/Star/Star.stories.tsx
+++ b/src/components/Star/Star.stories.tsx
@@ -25,12 +25,27 @@ Purple.args = {
   color: "purple",
 };
 
-export const Blue = Template.bind({});
-Blue.args = {
-  color: "blue",
+export const Turquoise = Template.bind({});
+Turquoise.args = {
+  color: "turquoise",
 };
 
 export const Gray = Template.bind({});
 Gray.args = {
   color: "gray",
+};
+
+export const Leaf = Template.bind({});
+Leaf.args = {
+  color: "leaf",
+};
+
+export const Orange = Template.bind({});
+Orange.args = {
+  color: "orange",
+};
+
+export const Magenta = Template.bind({});
+Magenta.args = {
+  color: "magenta",
 };

--- a/src/components/Star/StarStyle.tsx
+++ b/src/components/Star/StarStyle.tsx
@@ -1,14 +1,25 @@
+import { Properties } from "csstype";
 import { ReactSVG } from "react-svg";
 import styled, { css } from "styled-components";
 import { star } from "styles/colors";
 
 export type StarStyleProps = {
-  color?: "pink" | "yellow" | "purple" | "blue" | "gray";
+  color?:
+    | "pink"
+    | "yellow"
+    | "purple"
+    | "turquoise"
+    | "gray"
+    | "leaf"
+    | "orange"
+    | "magenta";
+  width?: Properties["width"];
+  height?: Properties["height"];
 };
 
-const defaultStyle = css`
-  width: 38px;
-  height: 38px;
+const defaultStyle = css<StarStyleProps>`
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
 `;
 
 const pinkStyle = css`
@@ -23,12 +34,24 @@ const purpleStyle = css`
   fill: ${star.purple};
 `;
 
-const blueStyle = css`
-  fill: ${star.blue};
+const turquoiseStyle = css`
+  fill: ${star.turquoise};
 `;
 
 const grayStyle = css`
   fill: ${star.gray};
+`;
+
+const leafStyle = css`
+  fill: ${star.leaf};
+`;
+
+const orangeStyle = css`
+  fill: ${star.orange};
+`;
+
+const magentaStyle = css`
+  fill: ${star.magenta};
 `;
 
 export const StarStyle = styled(ReactSVG)`
@@ -37,10 +60,15 @@ export const StarStyle = styled(ReactSVG)`
   ${({ color }) => color == "pink" && pinkStyle}
   ${({ color }) => color == "yellow" && yellowStyle}
   ${({ color }) => color == "purple" && purpleStyle}
-  ${({ color }) => color == "blue" && blueStyle}
+  ${({ color }) => color == "turquoise" && turquoiseStyle}
   ${({ color }) => color == "gray" && grayStyle}
+  ${({ color }) => color == "leaf" && leafStyle}
+  ${({ color }) => color == "orange" && orangeStyle}
+  ${({ color }) => color == "magenta" && magentaStyle}
 `;
 
 StarStyle.defaultProps = {
   color: "pink",
+  width: "38px",
+  height: "38px",
 };

--- a/src/components/Star/__snapshots__/Star.test.tsx.snap
+++ b/src/components/Star/__snapshots__/Star.test.tsx.snap
@@ -10,6 +10,8 @@ exports[`<Star /> snapshot test 1`] = `
 <svg
   class="c0"
   color="pink"
+  height="38px"
+  width="38px"
   xlink="http://www.w3.org/1999/xlink"
   xmlns="http://www.w3.org/2000/svg"
 />

--- a/src/components/StarBackground/StarBackground.tsx
+++ b/src/components/StarBackground/StarBackground.tsx
@@ -28,7 +28,7 @@ export const StarBackground: React.FC<Props> = ({
         <Star4 color="yellow" />
         <Star5 color="pink" />
         <Star6 color="purple" />
-        <Star7 color="blue" />
+        <Star7 color="turquoise" />
         <Star8 color="pink" />
       </StarBackgroundStyle>
     </>

--- a/src/components/StarBackground/__snapshots__/StarBackground.test.tsx.snap
+++ b/src/components/StarBackground/__snapshots__/StarBackground.test.tsx.snap
@@ -117,48 +117,64 @@ exports[`<Button /> snapshot test 1`] = `
   <svg
     class="c1 c2"
     color="purple"
+    height="38px"
+    width="38px"
     xlink="http://www.w3.org/1999/xlink"
     xmlns="http://www.w3.org/2000/svg"
   />
   <svg
     class="c1 c3"
     color="purple"
+    height="38px"
+    width="38px"
     xlink="http://www.w3.org/1999/xlink"
     xmlns="http://www.w3.org/2000/svg"
   />
   <svg
     class="c4 c5"
     color="yellow"
+    height="38px"
+    width="38px"
     xlink="http://www.w3.org/1999/xlink"
     xmlns="http://www.w3.org/2000/svg"
   />
   <svg
     class="c4 c6"
     color="yellow"
+    height="38px"
+    width="38px"
     xlink="http://www.w3.org/1999/xlink"
     xmlns="http://www.w3.org/2000/svg"
   />
   <svg
     class="c7 c8"
     color="pink"
+    height="38px"
+    width="38px"
     xlink="http://www.w3.org/1999/xlink"
     xmlns="http://www.w3.org/2000/svg"
   />
   <svg
     class="c1 c9"
     color="purple"
+    height="38px"
+    width="38px"
     xlink="http://www.w3.org/1999/xlink"
     xmlns="http://www.w3.org/2000/svg"
   />
   <svg
     class="c10 c11"
-    color="blue"
+    color="turquoise"
+    height="38px"
+    width="38px"
     xlink="http://www.w3.org/1999/xlink"
     xmlns="http://www.w3.org/2000/svg"
   />
   <svg
     class="c7 c12"
     color="pink"
+    height="38px"
+    width="38px"
     xlink="http://www.w3.org/1999/xlink"
     xmlns="http://www.w3.org/2000/svg"
   />

--- a/src/styles/GlobalStyle/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle/GlobalStyle.tsx
@@ -11,6 +11,8 @@ export const GlobalStyle = createGlobalStyle<Props>`
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     font-weight: ${FONT_WEIGHT.REGULAR};
+    font-feature-settings: 'palt' on;
+    color: ${global.font};
 
     // Base Color
     background-color: ${global.base};

--- a/src/styles/colors/semantics.ts
+++ b/src/styles/colors/semantics.ts
@@ -33,6 +33,7 @@ import {
   GRAY_100,
   GRAY_20,
   GRAY_30,
+  GRAY_40,
   GRAY_50,
   GRAY_60,
   GRAY_80,
@@ -208,6 +209,10 @@ export const avatar = {
   pink: {
     border: PINK_40,
     background: PINK_10,
+  },
+  gray: {
+    border: GRAY_40,
+    background: GRAY_20,
   },
   anonymous: {
     avatar: GRAY_50,

--- a/src/styles/colors/semantics.ts
+++ b/src/styles/colors/semantics.ts
@@ -43,6 +43,7 @@ import {
 export const global = {
   base: GRAY_00,
   main: TURQUOISE_50,
+  font: GRAY_100,
 } as const;
 
 export const button = {
@@ -50,6 +51,7 @@ export const button = {
   black: {
     surface: GRAY_90,
     side: GRAY_100,
+    font: WHITE,
     hover: {
       surface: GRAY_80,
       side: GRAY_90,
@@ -58,18 +60,27 @@ export const button = {
   blue: {
     surface: BLUE_TO_PURPLE,
     side: BLUE_TO_PURPLE_SHADOW,
+    font: WHITE,
   },
   pink: {
     surface: PINK_TO_ORANGE,
     side: PINK_TO_ORANGE_SHADOW,
+    font: WHITE,
   },
   green: {
     surface: GREEN_50,
     side: GREEN_60,
+    font: WHITE,
+  },
+  white: {
+    surface: GRAY_10,
+    side: GRAY_30,
+    font: GRAY_80,
   },
   disabled: {
     surface: GRAY_50,
     side: GRAY_60,
+    font: WHITE,
   },
 } as const;
 
@@ -97,8 +108,11 @@ export const star = {
   pink: RED_40,
   yellow: "#FFC047",
   purple: PURPLE_40,
-  blue: TURQUOISE_50,
+  turquoise: TURQUOISE_50,
   gray: GRAY_30,
+  leaf: LEAF_50,
+  orange: ORANGE_50,
+  magenta: PINK_50,
 } as const;
 
 export const algo = {

--- a/src/types/utils.d.ts
+++ b/src/types/utils.d.ts
@@ -1,6 +1,10 @@
 import { IconPrototype } from "components/icons/components/IconPrototype/IconPrototype";
 import { ComponentProps } from "react";
 
+export type Icon16 = {
+  size?: 16 | any;
+} & Omit<ComponentProps<typeof IconPrototype>, "filename" | "size">;
+
 export type Icon24 = {
   size?: 24 | any;
 } & Omit<ComponentProps<typeof IconPrototype>, "filename" | "size">;


### PR DESCRIPTION
# チケット
- [player plate 実装](https://www.notion.so/player-plate-f9a5c75f98fa4ce8a43f1a5d81371c38)

# やったこと
  - PlayerPlate/Meのデザインを実装
  - PlayerPlate/Otherのデザインを実装
  - PlayerPlate/*のためのサブコンポーネントを実装
    - PlayerPlateCard : PlayerPlate/*の共通デザインを括りだしたコンポーネント
    - Badge : ユーザー称号のデザイン
    - Status : カードの下のステータスを表すコンポーネント
# その他
  - Avatarにgrayカラーを追加
    - カードのAvatarに灰色カラーがあったため追加
# スクショ
  - PlayerPlate/Me，ユーザ，画像あり，ターコイズ，default
![image](https://user-images.githubusercontent.com/26971566/199485601-88c9d6b4-8bdd-4a54-813c-de7519f8a505.png)

  - PlayerPlate/Me，ユーザ，画像なし，リーフ，ready
![image](https://user-images.githubusercontent.com/26971566/199485651-15180e59-5516-4ab5-9f29-0dc813afe7ad.png)

  - PlayerPlate/Other，オレンジ，disconnecting
![image](https://user-images.githubusercontent.com/26971566/199485741-db1c852d-bef0-4c7b-aa86-dad52422103e.png)

  - PlayerPlate/Other，マゼンタ，bot
![image](https://user-images.githubusercontent.com/26971566/199485851-f850769c-3e59-4687-b6e5-686bbb0700be.png)

  - PlayerPlate/Other，マゼンタ，waiting
![image](https://user-images.githubusercontent.com/26971566/199485932-4e428de8-3d7e-429c-9ba4-5722860c536a.png)
