### PR TITLE
PrivateRouteでログインしてなかったらトップに飛ぶようにする

### DIFF
--- a/src/components/SignInScreen/SignInScreen.tsx
+++ b/src/components/SignInScreen/SignInScreen.tsx
@@ -39,7 +39,7 @@ export const SignInScreen: React.FC<Props> = (props: Props) => {
 
   useEffect(() => {
     if (isLogin && auth.currentUser && !auth.currentUser?.isAnonymous) {
-      navigate(redirectUrl);
+      navigate(redirectUrl, { replace: true });
     }
   }, [isLogin, auth.currentUser?.isAnonymous]);
 

--- a/src/pages/Code/Coding/hooks/useCodeHooks.tsx
+++ b/src/pages/Code/Coding/hooks/useCodeHooks.tsx
@@ -84,7 +84,7 @@ export const useCodingState = () => {
           1,
           "1"
         );
-        navigate(`/free-coding/${code.id}/`);
+        navigate(`/free-coding/${code.id}/`, { replace: true });
       }
       await setTimeout(() => {}, 5000);
       setLoading(false);

--- a/src/pages/Start/components/AnonymousLoginFrom/hooks/useAnonymousLoginFormState.ts
+++ b/src/pages/Start/components/AnonymousLoginFrom/hooks/useAnonymousLoginFormState.ts
@@ -16,7 +16,7 @@ export const useAnonymousLoginFormState = (): IResponse => {
     setAnonymousLoginBtnDisabled(true);
     signInAnonymously(getAuth())
       .then(() => {
-        navigate("/select-mode");
+        navigate("/select-mode", { replace: true });
       })
       .catch(() => {
         setAnonymousLoginBtnDisabled(false);

--- a/src/services/user/user.ts
+++ b/src/services/user/user.ts
@@ -123,7 +123,9 @@ export const signInAsync = (user: FirebaseUser) => {
             }
           }
         })
-        .catch();
+        .catch(() => {
+          dispatch(signOut());
+        });
     });
   };
 };
@@ -142,6 +144,8 @@ export const setCallBackToSyncUser = () => {
       if (user) {
         console.log("setCallBackToSyncUser", user);
         dispatch(signInAsync(user));
+      } else {
+        dispatch(signOut());
       }
     });
     dispatch(setUnRegisterObserver(observer));

--- a/src/utils/PrivateRoute.tsx
+++ b/src/utils/PrivateRoute.tsx
@@ -19,6 +19,6 @@ export const PrivateRoute: React.FC<Props> = ({
   } else if (isLogin) {
     return <RouteComponent />;
   } else {
-    return <Navigate to={redirectUrl || "/start"} />;
+    return <Navigate replace to={redirectUrl || "/start"} />;
   }
 };

--- a/src/utils/__snapshots__/PrivateRoute.test.tsx.snap
+++ b/src/utils/__snapshots__/PrivateRoute.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`privateRoute privateRoute snapshot test 1`] = `
 Array [
   <Navigate
+    replace={true}
     to="/event"
   />,
 ]


### PR DESCRIPTION
# チケット
- [PrivateRouteでログインしてなかったらトップに飛ぶようにする](https://www.notion.so/PrivateRoute-58278fce9af84737959706fe1b211312)

# やったこと
- PrivateRouteのページで未ログイン状態だと「ロード中」から進まない問題を解決
  - 未ログイン状態だとトップにリダイレクトされるように修正
- リダイレクトとなるページ遷移のnavigate設定を修正