### PR TITLE
エラーメッセージをログに表示

### DIFF
--- a/src/hooks/CodeAPIHooks/useCodeAPI.ts
+++ b/src/hooks/CodeAPIHooks/useCodeAPI.ts
@@ -364,7 +364,11 @@ export const useCodeAPI = (): IResponse => {
         })
         .catch((err) => {
           setLoading(false);
-          setError(`testCodeAPIError${err}`);
+          const errorResponse = String(err.response.data);
+          const end = errorResponse.indexOf("Request"); //上手く検索できなかった
+          const displayText =
+            end != -1 ? errorResponse.substr(0, end) : errorResponse;
+          setError(displayText);
           return rejects(new Error(error));
         });
     });

--- a/src/hooks/ResultHooks/useResult.ts
+++ b/src/hooks/ResultHooks/useResult.ts
@@ -12,6 +12,7 @@ export type IResponse = {
    * 状態をリセットする
    */
   reset: () => void;
+  error: string | undefined;
 };
 
 export type ResultState = {
@@ -37,7 +38,7 @@ export const useResult = (): IResponse => {
   const [resultState, setResultState] = useState<ResultState>({
     ...initialState,
   });
-  const { testCode: testCodeOnAPI } = useCodeAPI();
+  const { testCode: testCodeOnAPI, error } = useCodeAPI();
 
   const _setIsFailed = useCallback((isFailed: boolean) => {
     setResultState((current) => ({
@@ -69,5 +70,6 @@ export const useResult = (): IResponse => {
     resultState,
     testCode,
     reset,
+    error,
   };
 };

--- a/src/pages/Code/Coding/Coding.test.tsx
+++ b/src/pages/Code/Coding/Coding.test.tsx
@@ -79,6 +79,7 @@ const initialState: IResponse = {
   closePanelHandler: jest.fn(),
   panelState: "log",
   changeStep: jest.fn(),
+  error: undefined,
 };
 
 describe("<CodeCoding />", () => {

--- a/src/pages/Code/Coding/Coding.tsx
+++ b/src/pages/Code/Coding/Coding.tsx
@@ -52,6 +52,8 @@ export const CodeCoding: React.FC<Props> = () => {
     changeStep,
     // その他
     backLinkRoute,
+    //エラーレスポンス
+    error,
   } = useCodingState();
   if (loading) {
     return (
@@ -95,6 +97,8 @@ export const CodeCoding: React.FC<Props> = () => {
           />
         </ContainerMain>
         <LogPanel onCloseButtonClick={closePanelHandler} state={panelState}>
+          {panelState == "log" &&<>
+          {error}</>}
           {turnLog &&
             panelState == "log" &&
             turnLog.map((turn, index) => {

--- a/src/pages/Code/Coding/Coding.tsx
+++ b/src/pages/Code/Coding/Coding.tsx
@@ -62,7 +62,6 @@ export const CodeCoding: React.FC<Props> = () => {
       </div>
     );
   }
-  console.log(code?.step);
   return (
     <CodingStyle>
       <Background color="blue" />
@@ -97,8 +96,7 @@ export const CodeCoding: React.FC<Props> = () => {
           />
         </ContainerMain>
         <LogPanel onCloseButtonClick={closePanelHandler} state={panelState}>
-          {panelState == "log" &&<>
-          {error}</>}
+          {panelState == "log" && <>{error}</>}
           {turnLog &&
             panelState == "log" &&
             turnLog.map((turn, index) => {

--- a/src/pages/Code/Coding/__snapshots__/Coding.test.tsx.snap
+++ b/src/pages/Code/Coding/__snapshots__/Coding.test.tsx.snap
@@ -73,6 +73,7 @@ Array [
         onCloseButtonClick={[MockFunction]}
         state="log"
       >
+        <React.Fragment />
         <LogItem
           log="aaa"
           turnNum={1}

--- a/src/pages/Code/Coding/hooks/useCodeHooks.tsx
+++ b/src/pages/Code/Coding/hooks/useCodeHooks.tsx
@@ -88,6 +88,8 @@ export type IResponse = {
   closePanelHandler: () => void;
   backLinkRoute: string;
   changeStep: (step: number) => void;
+  /** エラーレスポンス */
+  error: string | undefined;
 };
 
 export const useCodingState = (): IResponse => {
@@ -109,6 +111,7 @@ export const useCodingState = (): IResponse => {
   }, []);
 
   // hooksの宣言
+<<<<<<< HEAD
   const {
     codeState,
     createCodeDefault,
@@ -117,6 +120,11 @@ export const useCodingState = (): IResponse => {
     changeStep,
   } = useCode(codeId);
   const { resultState, testCode, reset } = useResult();
+=======
+  const { codeState, createCodeDefault, updateCodeOnlyFront, saveCode } =
+    useCode(codeId);
+  const { resultState, testCode, reset, error } = useResult();
+>>>>>>> 0dfd007 (エラーメッセージをログに表示)
   const { dummyLoadingState, startDummyLoad } = useDummyLoading(5000);
   const { monacoEditorState, handleEditorDidMount } = useMonacoEditor();
   const { unityContext, unityStatus, startGame } = useUnityGame("SquarePaint");
@@ -260,6 +268,7 @@ export const useCodingState = (): IResponse => {
     showLog: showTurnLog,
     showMessage: switchDisplay === "message" || loading,
     code: codeState.code,
+    error,
     turnLog: resultState.simulationJson?.turn,
     handleEditorDidMount,
     unityContext,

--- a/src/pages/Code/Coding/hooks/useCodeHooks.tsx
+++ b/src/pages/Code/Coding/hooks/useCodeHooks.tsx
@@ -111,7 +111,6 @@ export const useCodingState = (): IResponse => {
   }, []);
 
   // hooksの宣言
-<<<<<<< HEAD
   const {
     codeState,
     createCodeDefault,
@@ -119,12 +118,7 @@ export const useCodingState = (): IResponse => {
     saveCode,
     changeStep,
   } = useCode(codeId);
-  const { resultState, testCode, reset } = useResult();
-=======
-  const { codeState, createCodeDefault, updateCodeOnlyFront, saveCode } =
-    useCode(codeId);
   const { resultState, testCode, reset, error } = useResult();
->>>>>>> 0dfd007 (エラーメッセージをログに表示)
   const { dummyLoadingState, startDummyLoad } = useDummyLoading(5000);
   const { monacoEditorState, handleEditorDidMount } = useMonacoEditor();
   const { unityContext, unityStatus, startGame } = useUnityGame("SquarePaint");


### PR DESCRIPTION
急いでSSしたのでフォント読み込まれてないけど
生レスポンスは不要な情報を大量に含むので最上部の必要なところだけ表示
検索部分の実装が急ぎすぎて負債
<img width="650" alt="image" src="https://user-images.githubusercontent.com/15964431/213457347-547ffd98-f8c0-4a19-b12c-a43f83d8c466.png">
