### PR TITLE
ルームIDをBase32を使用した４文字IDに短縮

### DIFF
--- a/src/hooks/RoomSyncHooks/useRoomSync.ts
+++ b/src/hooks/RoomSyncHooks/useRoomSync.ts
@@ -149,8 +149,9 @@ export const createRoomAsync = (
       host: user.id,
       status: "waiting",
     };
-    const dbRef = await pushRoomAsync(roomInfo);
-    const key = dbRef.key;
+    const room = await pushRoomAsync(roomInfo);
+    const key = room?.key;
+    // TODO: 部屋に入れなかった時の処理がいつか必要
     if (key) {
       await dispatch(_enterRoomAsync(key, user));
     }

--- a/src/services/RoomSync/DBListener/DBListener.test.ts
+++ b/src/services/RoomSync/DBListener/DBListener.test.ts
@@ -111,7 +111,7 @@ describe("Test Cases for Reducers of DBListener", () => {
     it("正常系", async () => {
       await store.dispatch(startRoomDBSync("roomId"));
       expect(onValueMock).toBeCalledTimes(1);
-      expect(onValueMock.mock.calls[0][0]).toBe("/RoomApp/rooms/roomId"); //第一引数
+      expect(onValueMock.mock.calls[0][0]).toBe("/RoomApp/rooms/R00M1D"); //第一引数
     });
 
     it("異常系１（ルームIDが空文字列の場合）", async () => {
@@ -140,13 +140,13 @@ describe("Test Cases for Reducers of DBListener", () => {
       expect(onChildChangedMock).toBeCalledTimes(1);
       expect(onChildMovedMock).toBeCalledTimes(1);
       expect(onChildRemovedMock).toBeCalledTimes(1);
-      expect(onChildAddedMock.mock.calls[0][0]).toBe("/RoomApp/members/roomId"); //第一引数
+      expect(onChildAddedMock.mock.calls[0][0]).toBe("/RoomApp/members/R00M1D"); //第一引数
       expect(onChildChangedMock.mock.calls[0][0]).toBe(
-        "/RoomApp/members/roomId"
+        "/RoomApp/members/R00M1D"
       ); //第一引数
-      expect(onChildMovedMock.mock.calls[0][0]).toBe("/RoomApp/members/roomId"); //第一引数
+      expect(onChildMovedMock.mock.calls[0][0]).toBe("/RoomApp/members/R00M1D"); //第一引数
       expect(onChildRemovedMock.mock.calls[0][0]).toBe(
-        "/RoomApp/members/roomId"
+        "/RoomApp/members/R00M1D"
       ); //第一引数
     });
 
@@ -185,13 +185,13 @@ describe("Test Cases for Reducers of DBListener", () => {
       expect(onChildChangedMock).toBeCalledTimes(1);
       expect(onChildMovedMock).toBeCalledTimes(1);
       expect(onChildRemovedMock).toBeCalledTimes(1);
-      expect(onChildAddedMock.mock.calls[0][0]).toBe("/RoomApp/actions/roomId"); //第一引数
+      expect(onChildAddedMock.mock.calls[0][0]).toBe("/RoomApp/actions/R00M1D"); //第一引数
       expect(onChildChangedMock.mock.calls[0][0]).toBe(
-        "/RoomApp/actions/roomId"
+        "/RoomApp/actions/R00M1D"
       ); //第一引数
-      expect(onChildMovedMock.mock.calls[0][0]).toBe("/RoomApp/actions/roomId"); //第一引数
+      expect(onChildMovedMock.mock.calls[0][0]).toBe("/RoomApp/actions/R00M1D"); //第一引数
       expect(onChildRemovedMock.mock.calls[0][0]).toBe(
-        "/RoomApp/actions/roomId"
+        "/RoomApp/actions/R00M1D"
       ); //第一引数
     });
 
@@ -226,7 +226,7 @@ describe("Test Cases for Reducers of DBListener", () => {
   describe("onDisconnectのテスト", () => {
     it("setUserStateOnDisconnect", () => {
       setUserStateOnDisconnect("roomId", "userId", users["userId"]);
-      expect(onDisconnect).lastCalledWith("/RoomApp/members/roomId/userId");
+      expect(onDisconnect).lastCalledWith("/RoomApp/members/R00M1D/userId");
       expect(disconnectFunc.set).lastCalledWith(users["userId"]);
     });
     it("updateUserStateOnDisconnect", () => {
@@ -235,7 +235,7 @@ describe("Test Cases for Reducers of DBListener", () => {
         status: "disconnect",
         codeId: null,
       });
-      expect(onDisconnect).lastCalledWith("/RoomApp/members/roomId/userId");
+      expect(onDisconnect).lastCalledWith("/RoomApp/members/R00M1D/userId");
       expect(disconnectFunc.update).lastCalledWith({
         displayName: "update user",
         status: "disconnect",
@@ -244,7 +244,7 @@ describe("Test Cases for Reducers of DBListener", () => {
     });
     it("removeUserStateOnDisconnect", () => {
       removeUserStateOnDisconnect("roomId", "userId");
-      expect(onDisconnect).lastCalledWith("/RoomApp/members/roomId/userId");
+      expect(onDisconnect).lastCalledWith("/RoomApp/members/R00M1D/userId");
       expect(disconnectFunc.remove).toBeCalledTimes(1);
     });
     it("setUserStateWithPriorityOnDisconnect", () => {
@@ -254,12 +254,12 @@ describe("Test Cases for Reducers of DBListener", () => {
         users["userId"],
         1
       );
-      expect(onDisconnect).lastCalledWith("/RoomApp/members/roomId/userId");
+      expect(onDisconnect).lastCalledWith("/RoomApp/members/R00M1D/userId");
       expect(disconnectFunc.setWithPriority).lastCalledWith(users["userId"], 1);
     });
     it("cancelUserStateOnDisconnect", () => {
       cancelUserStateOnDisconnect("roomId", "userId");
-      expect(onDisconnect).lastCalledWith("/RoomApp/members/roomId/userId");
+      expect(onDisconnect).lastCalledWith("/RoomApp/members/R00M1D/userId");
       expect(disconnectFunc.cancel).toBeCalledTimes(1);
     });
   });

--- a/src/services/RoomSync/DBListener/DBListener.ts
+++ b/src/services/RoomSync/DBListener/DBListener.ts
@@ -19,6 +19,7 @@ import {
   ActionsRef,
   addAction,
   addMember,
+  EncodeRoomId,
   enterRoom,
   exitRoom,
   ListReducerArg,
@@ -46,8 +47,15 @@ import {
 export const startRoomDBSync = (roomId: string): ThunkResult<void> => {
   return (dispatch: any) => {
     if (roomId == "") return;
+    //roomIdはBase32なのでエンコードしてから使用する
+    const encodedRoomId = EncodeRoomId(roomId);
     dispatch(
-      _startValueDBSync("rooms", child(RoomsRef(), roomId), enterRoom, exitRoom)
+      _startValueDBSync(
+        "rooms",
+        child(RoomsRef(), encodedRoomId),
+        enterRoom,
+        exitRoom
+      )
     );
   };
 };
@@ -70,10 +78,12 @@ export const stopRoomDBSync = (): ThunkResult<void> => {
 export const startMembersDBSync = (roomId: string): ThunkResult<void> => {
   return (dispatch: any) => {
     if (roomId == "") return;
+    //roomIdはBase32なのでエンコードしてから使用する
+    const encodedRoomId = EncodeRoomId(roomId);
     dispatch(
       _startListDBSync(
         "members",
-        child(MembersRef(), roomId),
+        child(MembersRef(), encodedRoomId),
         addMember,
         updateMember,
         moveMember,
@@ -106,8 +116,10 @@ export const setUserStateOnDisconnect = async (
   value: UserState
 ) => {
   if (userId == "") return;
+  //roomIdはBase32なのでエンコードしてから使用する
+  const encodedRoomId = EncodeRoomId(roomId);
   await _setValueOnDisconnect(
-    child(MembersRef(), `${roomId}/${userId}`),
+    child(MembersRef(), `${encodedRoomId}/${userId}`),
     value
   );
 };
@@ -124,8 +136,13 @@ export const updateUserStateOnDisconnect = async (
   userId: string,
   value: UserStateUpdate
 ) => {
-  if (userId == "") return;
-  await _updateOnDisconnect(child(MembersRef(), `${roomId}/${userId}`), value);
+  if (roomId == "" || userId == "") return;
+  //roomIdはBase32なのでエンコードしてから使用する
+  const encodedRoomId = EncodeRoomId(roomId);
+  await _updateOnDisconnect(
+    child(MembersRef(), `${encodedRoomId}/${userId}`),
+    value
+  );
 };
 
 /**
@@ -138,8 +155,10 @@ export const removeUserStateOnDisconnect = async (
   roomId: string,
   userId: string
 ) => {
-  if (userId == "") return;
-  await _removeOnDisconnect(child(MembersRef(), `${roomId}/${userId}`));
+  if (roomId == "" || userId == "") return;
+  //roomIdはBase32なのでエンコードしてから使用する
+  const encodedRoomId = EncodeRoomId(roomId);
+  await _removeOnDisconnect(child(MembersRef(), `${encodedRoomId}/${userId}`));
 };
 
 /**
@@ -157,8 +176,10 @@ export const setUserStateWithPriorityOnDisconnect = async (
   priority: string | number | null
 ) => {
   if (userId == "") return;
+  //roomIdはBase32なのでエンコードしてから使用する
+  const encodedRoomId = EncodeRoomId(roomId);
   await _setWithPriorityOnDisconnect(
-    child(MembersRef(), `${roomId}/${userId}`),
+    child(MembersRef(), `${encodedRoomId}/${userId}`),
     value,
     priority
   );
@@ -174,8 +195,10 @@ export const cancelUserStateOnDisconnect = async (
   roomId: string,
   userId: string
 ) => {
-  if (userId == "") return;
-  await _cancelOnDisconnect(child(MembersRef(), `${roomId}/${userId}`));
+  if (roomId == "" || userId == "") return;
+  //roomIdはBase32なのでエンコードしてから使用する
+  const encodedRoomId = EncodeRoomId(roomId);
+  await _cancelOnDisconnect(child(MembersRef(), `${encodedRoomId}/${userId}`));
 };
 
 /**
@@ -186,10 +209,12 @@ export const cancelUserStateOnDisconnect = async (
 export const startActionsDBSync = (roomId: string): ThunkResult<void> => {
   return (dispatch: any) => {
     if (roomId == "") return;
+    //roomIdはBase32なのでエンコードしてから使用する
+    const encodedRoomId = EncodeRoomId(roomId);
     dispatch(
       _startListDBSync(
         "actions",
-        child(ActionsRef(), roomId),
+        child(ActionsRef(), encodedRoomId),
         addAction,
         updateAction,
         moveAction,

--- a/src/services/RoomSync/DBOperator/DBOperator.test.ts
+++ b/src/services/RoomSync/DBOperator/DBOperator.test.ts
@@ -72,7 +72,7 @@ describe("Test Cases for Reducers of DBOperator", () => {
       });
       const result = await getRoomAsync("roomId");
       expect(getMock).toBeCalledTimes(1);
-      expect(getMock).lastCalledWith("/RoomApp/rooms/roomId");
+      expect(getMock).lastCalledWith("/RoomApp/rooms/R00M1D");
       expect(result).toEqual(roomInfo);
     });
 
@@ -99,7 +99,7 @@ describe("Test Cases for Reducers of DBOperator", () => {
       });
       const result = await getMemberAsync("roomId", "userId");
       expect(getMock).toBeCalledTimes(1);
-      expect(getMock).lastCalledWith("/RoomApp/members/roomId/userId");
+      expect(getMock).lastCalledWith("/RoomApp/members/R00M1D/userId");
       expect(result).toEqual(users["userId"]);
     });
 
@@ -121,11 +121,26 @@ describe("Test Cases for Reducers of DBOperator", () => {
 
   describe("test of pushRoomAsync", () => {
     it("正常系", async () => {
-      pushMock.mockResolvedValue("reference");
+      // ID重複の部屋が見つからない場合
+      getMock.mockResolvedValue({
+        val: () => undefined,
+      });
       const result = await pushRoomAsync(roomInfo);
-      expect(pushMock).toBeCalledTimes(1);
-      expect(pushMock).lastCalledWith("/RoomApp/rooms", roomInfo);
-      expect(result).toEqual("reference");
+      expect(setMock).toBeCalledTimes(1);
+      expect(setMock.mock.calls[0][0]).toMatch(/\/RoomApp\/rooms\/.{4}/);
+      expect(setMock.mock.calls[0][1]).toEqual(roomInfo);
+      expect(result?.key).toMatch(/.{4}/);
+      expect(result?.data).toEqual(roomInfo);
+    });
+
+    it("異常系（IDが重複し続けた場合）", async () => {
+      // ID重複の部屋が見つからない場合
+      getMock.mockResolvedValue({
+        val: () => roomInfo,
+      });
+      const result = await pushRoomAsync(roomInfo);
+      expect(setMock).toBeCalledTimes(0);
+      expect(result).toBe(undefined);
     });
   });
 
@@ -133,7 +148,7 @@ describe("Test Cases for Reducers of DBOperator", () => {
     it("正常系", async () => {
       await updateRoomAsync("roomId", roomInfo);
       expect(updateMock).toBeCalledTimes(1);
-      expect(updateMock).lastCalledWith("/RoomApp/rooms/roomId", roomInfo);
+      expect(updateMock).lastCalledWith("/RoomApp/rooms/R00M1D", roomInfo);
     });
 
     it("異常系１（roomIdが空文字列の場合）", async () => {
@@ -146,9 +161,9 @@ describe("Test Cases for Reducers of DBOperator", () => {
     it("正常系", async () => {
       await destroyRoomAsync("roomId");
       expect(setMock).toBeCalledTimes(3);
-      expect(setMock.mock.calls[0]).toEqual(["/RoomApp/rooms/roomId", null]);
-      expect(setMock.mock.calls[1]).toEqual(["/RoomApp/members/roomId", null]);
-      expect(setMock.mock.calls[2]).toEqual(["/RoomApp/actions/roomId", null]);
+      expect(setMock.mock.calls[0]).toEqual(["/RoomApp/rooms/R00M1D", null]);
+      expect(setMock.mock.calls[1]).toEqual(["/RoomApp/members/R00M1D", null]);
+      expect(setMock.mock.calls[2]).toEqual(["/RoomApp/actions/R00M1D", null]);
     });
 
     it("異常系１（roomIdが空文字列の場合）", async () => {
@@ -161,7 +176,7 @@ describe("Test Cases for Reducers of DBOperator", () => {
     it("正常系", async () => {
       await initMemberAsync("roomId", user);
       expect(updateMock).toBeCalledTimes(1);
-      expect(updateMock).lastCalledWith("/RoomApp/members/roomId/" + user.id, {
+      expect(updateMock).lastCalledWith("/RoomApp/members/R00M1D/" + user.id, {
         displayName: user.displayName,
         ready: false,
         status: "waiting",
@@ -179,7 +194,7 @@ describe("Test Cases for Reducers of DBOperator", () => {
       await updateMemberAsync("roomId", "userId", users["userId"]);
       expect(updateMock).toBeCalledTimes(1);
       expect(updateMock).lastCalledWith(
-        "/RoomApp/members/roomId/userId",
+        "/RoomApp/members/R00M1D/userId",
         users["userId"]
       );
     });
@@ -199,7 +214,7 @@ describe("Test Cases for Reducers of DBOperator", () => {
     it("正常系", async () => {
       await removeMemberAsync("roomId", "userId");
       expect(setMock).toBeCalledTimes(1);
-      expect(setMock).lastCalledWith("/RoomApp/members/roomId/userId", null);
+      expect(setMock).lastCalledWith("/RoomApp/members/R00M1D/userId", null);
     });
 
     it("異常系１（roomIdが空文字列の場合）", async () => {
@@ -218,7 +233,7 @@ describe("Test Cases for Reducers of DBOperator", () => {
       await addActionAsync("roomId", actions["actionId"]);
       expect(pushMock).toBeCalledTimes(1);
       expect(pushMock).lastCalledWith(
-        "/RoomApp/actions/roomId",
+        "/RoomApp/actions/R00M1D",
         actions["actionId"]
       );
     });
@@ -234,7 +249,7 @@ describe("Test Cases for Reducers of DBOperator", () => {
       await updateActionAsync("roomId", "actionId", actions["actionId"]);
       expect(updateMock).toBeCalledTimes(1);
       expect(updateMock).lastCalledWith(
-        "/RoomApp/actions/roomId/actionId",
+        "/RoomApp/actions/R00M1D/actionId",
         actions["actionId"]
       );
     });
@@ -254,7 +269,7 @@ describe("Test Cases for Reducers of DBOperator", () => {
     it("正常系", async () => {
       await removeActionAsync("roomId", "actionId");
       expect(setMock).toBeCalledTimes(1);
-      expect(setMock).lastCalledWith("/RoomApp/actions/roomId/actionId", null);
+      expect(setMock).lastCalledWith("/RoomApp/actions/R00M1D/actionId", null);
     });
 
     it("異常系１（roomIdが空文字列の場合）", async () => {

--- a/src/services/RoomSync/RoomSync.ts
+++ b/src/services/RoomSync/RoomSync.ts
@@ -4,11 +4,16 @@ import { AnyAction } from "redux";
 import "firebase_config";
 import { ThunkAction } from "redux-thunk";
 import { RootState } from "store";
+import { EncodeBase32, GenerateBase32ID } from "utils/Base32";
+import { ROOM_ID_LENGTH } from "styles/constants/constants";
 
 export const RootRef = () => ref(getDatabase(), "/RoomApp");
 export const RoomsRef = () => child(RootRef(), "rooms");
 export const MembersRef = () => child(RootRef(), "members");
 export const ActionsRef = () => child(RootRef(), "actions");
+
+export const GenerateRoomId = () => GenerateBase32ID(ROOM_ID_LENGTH);
+export const EncodeRoomId = (roomId: string) => EncodeBase32(roomId);
 
 /**
  * ルーム情報

--- a/src/styles/constants/constants.ts
+++ b/src/styles/constants/constants.ts
@@ -8,3 +8,6 @@ export const FONT_WEIGHT = {
   REGULAR: 400,
   BOLD: 700,
 };
+
+/** ルームIDのID長 */
+export const ROOM_ID_LENGTH = 4;

--- a/src/utils/Base32.test.tsx
+++ b/src/utils/Base32.test.tsx
@@ -1,0 +1,14 @@
+import { EncodeBase32, GenerateBase32ID } from "./Base32";
+
+describe("base32", () => {
+  it("generate base32 id", () => {
+    const id = GenerateBase32ID(4);
+    expect(id).toBeTruthy();
+  });
+
+  it("encode base32", () => {
+    const str = "0123IiLlOoabc";
+    const encodedStr = EncodeBase32(str);
+    expect(encodedStr).toBe("0123111100ABC");
+  });
+});

--- a/src/utils/Base32.tsx
+++ b/src/utils/Base32.tsx
@@ -1,0 +1,65 @@
+/**
+ * http://www.crockford.com/base32.html
+ */
+
+const BASE32_LETTERS = [
+  "0",
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "A",
+  "B",
+  "C",
+  "D",
+  "E",
+  "F",
+  "G",
+  "H",
+  "J",
+  "K",
+  "M",
+  "N",
+  "P",
+  "Q",
+  "R",
+  "S",
+  "T",
+  "V",
+  "W",
+  "X",
+  "Y",
+  "Z",
+];
+
+/**
+ * Base32の文字列でIDを生成する
+ * @param length ID長
+ * @returns 指定されたID長のBase32ID
+ */
+export const GenerateBase32ID = (length: number) => {
+  let id = "";
+
+  for (let i = 0; i < length; i++) {
+    id += BASE32_LETTERS[Math.floor(Math.random() * BASE32_LETTERS.length)];
+  }
+
+  return id;
+};
+
+/**
+ * 受け取った文字列をBase32でエンコードする
+ * 例：iolabc123 => 100ABC123
+ * @param str エンコードする文字列
+ * @returns Base32でエンコードした文字列
+ */
+export const EncodeBase32 = (str: string) => {
+  const upperStr = str.toUpperCase();
+  const encodedStr = upperStr.replace(/[O]/g, "0").replace(/[IL]/g, "1");
+  return encodedStr;
+};


### PR DESCRIPTION
### チケット
- [URLの短縮](https://www.notion.so/URL-2aaa310bd7124dcbb21e857b6c58291f)

### やったこと
- Base32を実装
  - Base32を用いた任意長IDの生成関数
  - Base32へのエンコード関数
  - Base32の仕様はこちらを参照
    - [Base32](http://www.crockford.com/base32.html)
- ルームIDをID長4文字のBase32IDに短縮
  - 例：P4SD、1AB3など
  - 一応、ルームIDの重複チェックをしています
  - 32^4種類作れるので、100万ほどの同時接続に耐えれます
    - ただし、ルームは全員が正しく退室しない場合は残るので、ルームを整理する定期ジョブが必要になる可能性があります。

### 備考
- Base32は人が読みやすいIDを目的とした文字セットです。
  - 例
    - 記号は含まない英数字のみのIDです。
    - `i`や`l`は1に、`o`は0にエンコードされます。
    - `u`は暴力的な英単語に含まれやすいので文字セットから外されています。