### PR TITLE
プレイヤープレートの表示の修正、待機画面のユーザアイコンの修正

### DIFF
--- a/src/components/PlayerPlate/Me/PlayerPlateMeStyle.tsx
+++ b/src/components/PlayerPlate/Me/PlayerPlateMeStyle.tsx
@@ -15,6 +15,10 @@ export const ColumnTopStye = styled.div`
     font-size: 30px;
     line-height: 43px;
     transform: matrix(1, 0, -0.08, 1, 0, 0);
+    max-width: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 `;
 
@@ -36,6 +40,10 @@ export const ColumnMiddleStye = styled.div`
     line-height: 150%;
     color: ${PlayerPlateColors.badge};
     text-align: center;
+    max-width: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 `;
 

--- a/src/components/PlayerPlate/Me/__snapshots__/PlayerPlateMe.test.tsx.snap
+++ b/src/components/PlayerPlate/Me/__snapshots__/PlayerPlateMe.test.tsx.snap
@@ -245,6 +245,10 @@ exports[`<PlayerPlateMe /> snapshot test 1`] = `
   -webkit-transform: matrix(1,0,-0.08,1,0,0);
   -ms-transform: matrix(1,0,-0.08,1,0,0);
   transform: matrix(1,0,-0.08,1,0,0);
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .c6 {
@@ -279,6 +283,10 @@ exports[`<PlayerPlateMe /> snapshot test 1`] = `
   line-height: 150%;
   color: #4A5373;
   text-align: center;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 @supports not (gap:10px) {

--- a/src/components/PlayerPlate/Other/PlayerPlateOtherStyle.tsx
+++ b/src/components/PlayerPlate/Other/PlayerPlateOtherStyle.tsx
@@ -20,6 +20,11 @@ export const ColumnTopStye = styled.div<ColumnTopProps>`
     font-size: 30px;
     line-height: 43px;
     transform: matrix(1, 0, -0.08, 1, 0, 0);
+
+    max-width: 100%;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
   }
 `;
 

--- a/src/components/PlayerPlate/Other/__snapshots__/PlayerPlateOther.test.tsx.snap
+++ b/src/components/PlayerPlate/Other/__snapshots__/PlayerPlateOther.test.tsx.snap
@@ -196,6 +196,10 @@ exports[`<PlayerPlateOther /> snapshot test 1`] = `
   -webkit-transform: matrix(1,0,-0.08,1,0,0);
   -ms-transform: matrix(1,0,-0.08,1,0,0);
   transform: matrix(1,0,-0.08,1,0,0);
+  max-width: 100%;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 @supports not (gap:16px) {

--- a/src/pages/RoomMatch/WaitingRoom/WaitingRoom.tsx
+++ b/src/pages/RoomMatch/WaitingRoom/WaitingRoom.tsx
@@ -101,7 +101,7 @@ export const RoomMatchWaitingRoom: React.FC<Props> = () => {
               selectedCodeName={labelize(selectedCode?.codeContent)}
               status={ready ? "ready" : "default"}
               userName={user.displayName}
-              userPhoto="/logo512.png"
+              userPhoto={user.picture}
             />
 
             <RightPanel>
@@ -139,12 +139,13 @@ export const RoomMatchWaitingRoom: React.FC<Props> = () => {
                             : "default"
                         }
                         userName={roomInfo.members[key].displayName}
-                        userPhoto="/logo512.png"
+                        userPhoto={roomInfo.members[key].picture}
                         userType="user"
                       />
                     </div>
                   );
                 })}
+                {/* 待機中 */}
                 {[1, 2, 3].map(
                   (i) =>
                     i >= roomInfo.memberKeys.length && (
@@ -155,7 +156,7 @@ export const RoomMatchWaitingRoom: React.FC<Props> = () => {
                         onClickChangeCPU={undefined}
                         status="waiting"
                         userName=""
-                        userPhoto="/logo512.png"
+                        userPhoto=""
                         userType="user"
                       />
                     )

--- a/src/pages/RoomMatch/WaitingRoom/__snapshots__/WaitingRoom.test.tsx.snap
+++ b/src/pages/RoomMatch/WaitingRoom/__snapshots__/WaitingRoom.test.tsx.snap
@@ -24,7 +24,7 @@ Array [
           selectedCodeName="print('hello world)'"
           status="ready"
           userName="user 2"
-          userPhoto="/logo512.png"
+          userPhoto="picture"
         />
         <styled.div>
           <styled.div>
@@ -52,7 +52,6 @@ Array [
                 onClickChangeCPU={[Function]}
                 status="default"
                 userName="host user"
-                userPhoto="/logo512.png"
                 userType="user"
               />
             </div>
@@ -63,7 +62,6 @@ Array [
                 onClickChangeCPU={[Function]}
                 status="ready"
                 userName="user 1"
-                userPhoto="/logo512.png"
                 userType="user"
               />
             </div>
@@ -72,7 +70,7 @@ Array [
               color="turquoise"
               status="waiting"
               userName=""
-              userPhoto="/logo512.png"
+              userPhoto=""
               userType="user"
             />
           </styled.div>

--- a/src/services/RoomSync/DBOperator/DBOperator.test.ts
+++ b/src/services/RoomSync/DBOperator/DBOperator.test.ts
@@ -163,6 +163,7 @@ describe("Test Cases for Reducers of DBOperator", () => {
       expect(updateMock).toBeCalledTimes(1);
       expect(updateMock).lastCalledWith("/RoomApp/members/roomId/" + user.id, {
         displayName: user.displayName,
+        picture: user.picture,
         ready: false,
         status: "waiting",
       });

--- a/src/services/RoomSync/DBOperator/DBOperator.ts
+++ b/src/services/RoomSync/DBOperator/DBOperator.ts
@@ -1,5 +1,6 @@
 import { child, get, push, set, update } from "firebase/database";
 import { User } from "services/user/user";
+import { removeUndefinedFromObject } from "utils/RemoveUndefinedFromObject";
 import {
   ActionsRef,
   MembersRef,
@@ -62,6 +63,7 @@ export const getMemberAsync = async (roomId: string, memberId: string) => {
   //メンバー情報にキャスト
   const member: UserState = {
     displayName: data.displayName,
+    picture: data.picture,
     ready: data.ready,
     status: data.status,
     codeId: data.codeId,
@@ -70,8 +72,10 @@ export const getMemberAsync = async (roomId: string, memberId: string) => {
   //チェック
   if (
     member.displayName === undefined ||
+    // pictureはundefined許容
     member.ready === undefined ||
     member.status === undefined
+    // codeIdはundefined許容
   )
     return;
 
@@ -123,6 +127,7 @@ export const initMemberAsync = async (
   user: User,
   userState: UserState = {
     displayName: user.displayName,
+    picture: user.picture,
     status: "waiting",
     ready: false,
   }
@@ -142,7 +147,8 @@ export const updateMemberAsync = async (
   userState: UserStateUpdate
 ) => {
   if (roomId == "" || id == "") return;
-  await update(child(MembersRef(), `${roomId}/${id}`), userState);
+  const updateData = removeUndefinedFromObject(userState);
+  await update(child(MembersRef(), `${roomId}/${id}`), updateData);
 };
 
 /**

--- a/src/services/RoomSync/RoomSync.ts
+++ b/src/services/RoomSync/RoomSync.ts
@@ -35,6 +35,7 @@ export type RoomInfo = {
  */
 export type UserState = {
   displayName: string;
+  picture?: string;
   /**
    * - waiting: 待機画面に居る
    * - watching: GameWatching画面にいる

--- a/src/utils/RemoveUndefinedFromObject.ts
+++ b/src/utils/RemoveUndefinedFromObject.ts
@@ -1,0 +1,5 @@
+export const removeUndefinedFromObject = (object: object) => {
+  return Object.fromEntries(
+    Object.entries(object).filter((items) => items[1] !== undefined)
+  );
+};


### PR DESCRIPTION
# やったこと
- プレイヤープレートで名前が長すぎると枠を飛び出るバグを修正
  - 飛び出る場合は...で省略するように修正
- 待機画面のユーザアイコンを表示するように修正
  - アイコンはfirebaseのrealtime dbで共有するように実装

# スクリーンショット
- プレイヤープレートの表示例
![image](https://user-images.githubusercontent.com/26971566/216110835-634a6fa1-e18e-4ed8-a544-a25f617dd5f3.png)

- 待機画面の表示例
  - 左から、アイコンあり、アイコンあり、アイコンなし、アイコン画像が無効なURL
![image](https://user-images.githubusercontent.com/26971566/216110327-67a835ef-8975-45ff-bfc1-4cb7121d616e.png)

