### PR TITLE
お助け関数説明ページへのリンク追加

### DIFF
--- a/src/pages/Code/Coding/Coding.test.tsx
+++ b/src/pages/Code/Coding/Coding.test.tsx
@@ -79,6 +79,7 @@ const initialState: IResponse = {
   closePanelHandler: jest.fn(),
   panelState: "log",
   changeStep: jest.fn(),
+  linkToNotion: jest.fn(),
 };
 
 describe("<CodeCoding />", () => {

--- a/src/pages/Code/Coding/Coding.tsx
+++ b/src/pages/Code/Coding/Coding.tsx
@@ -50,6 +50,7 @@ export const CodeCoding: React.FC<Props> = () => {
     toggleSettingHandler,
     closePanelHandler,
     changeStep,
+    linkToNotion,
     // その他
     backLinkRoute,
   } = useCodingState();
@@ -144,6 +145,7 @@ export const CodeCoding: React.FC<Props> = () => {
         {" "}
         <TabStyle value="LOG" onClick={toggleLogHandler} />
         <TabStyle value="SETTING" onClick={toggleSettingHandler} />
+        <TabStyle value="HELP" onClick={linkToNotion} />
       </TabWrap>
     </CodingStyle>
   );

--- a/src/pages/Code/Coding/__snapshots__/Coding.test.tsx.snap
+++ b/src/pages/Code/Coding/__snapshots__/Coding.test.tsx.snap
@@ -95,6 +95,10 @@ Array [
         onClick={[MockFunction]}
         value="SETTING"
       />
+      <Styled(Tab)
+        onClick={[MockFunction]}
+        value="HELP"
+      />
     </styled.div>
   </styled.div>,
 ]

--- a/src/pages/Code/Coding/hooks/useCodeHooks.tsx
+++ b/src/pages/Code/Coding/hooks/useCodeHooks.tsx
@@ -88,6 +88,7 @@ export type IResponse = {
   closePanelHandler: () => void;
   backLinkRoute: string;
   changeStep: (step: number) => void;
+  linkToNotion: () => void;
 };
 
 export const useCodingState = (): IResponse => {
@@ -247,6 +248,12 @@ export const useCodingState = (): IResponse => {
     if (showSetting) setShowSetting(false);
     if (showTurnLog) setShowTurnLog(false);
   };
+  const linkToNotion = () => {
+    window.open(
+      "https://four-forest-c7b.notion.site/4cb8096d110c47e19891d2df8a445122",
+      "_blank"
+    );
+  };
   return {
     state: {
       showTurnLog,
@@ -271,5 +278,6 @@ export const useCodingState = (): IResponse => {
     closePanelHandler,
     panelState,
     changeStep,
+    linkToNotion,
   };
 };


### PR DESCRIPTION
## チケット
- [お助けメソッドタブの追加](https://www.notion.so/b56b9c9bac0d4a53b4cdd7934dca1531)

## やったこと
- コーディング画面にHELPタブを作って[Notion](https://four-forest-c7b.notion.site/4cb8096d110c47e19891d2df8a445122)へリンクした。
![image](https://user-images.githubusercontent.com/15964431/217746021-175d4cb9-09d5-4881-9d7e-64105a62c22c.png)
