### PR TITLE
フレンド対戦モードで５人以上入ることができるバグを修正

### DIFF
--- a/src/hooks/RoomSyncHooks/useRoomSync.ts
+++ b/src/hooks/RoomSyncHooks/useRoomSync.ts
@@ -36,6 +36,11 @@ import {
 import { User } from "services/user/user";
 import { RootState } from "store";
 
+/**
+ * ルームに入れるメンバー数の上限
+ */
+const MAX_MEMBER_COUNT = 4;
+
 export const useRoomSync = () => {
   const room = useSelector((state: RootState) => state.room);
   const { user } = useSelector((state: RootState) => state.user);
@@ -176,7 +181,7 @@ export const enterRoomAsync = (
     //ルームが存在し、満員でないなら入室処理
     if (!room || !memberCount) {
       throw new Error(`roomId is not found`);
-    } else if (memberCount >= 4) {
+    } else if (memberCount >= MAX_MEMBER_COUNT) {
       throw new Error(`room is full`);
     } else {
       dispatch(_enterRoomAsync(roomId, user));

--- a/src/hooks/RoomSyncHooks/useRoomSync.ts
+++ b/src/hooks/RoomSyncHooks/useRoomSync.ts
@@ -14,6 +14,7 @@ import {
   addActionAsync,
   destroyRoomAsync,
   getRoomAsync,
+  getMemberCountAsync,
   initMemberAsync,
   pushRoomAsync,
   removeActionAsync,
@@ -170,12 +171,15 @@ export const enterRoomAsync = (
 ): ThunkResult<void> => {
   return async (dispatch: any) => {
     if (roomId == "") throw new Error(`roomId is empty`);
-    const data = await getRoomAsync(roomId);
-    //ルームが存在したら入室処理
-    if (data) {
-      dispatch(_enterRoomAsync(roomId, user));
-    } else {
+    const room = await getRoomAsync(roomId);
+    const memberCount = await getMemberCountAsync(roomId);
+    //ルームが存在し、満員でないなら入室処理
+    if (!room || !memberCount) {
       throw new Error(`roomId is not found`);
+    } else if (memberCount >= 4) {
+      throw new Error(`room is full`);
+    } else {
+      dispatch(_enterRoomAsync(roomId, user));
     }
   };
 };

--- a/src/pages/RoomMatch/Lobby/hooks/useLobbyState.ts
+++ b/src/pages/RoomMatch/Lobby/hooks/useLobbyState.ts
@@ -49,6 +49,8 @@ export const useLobbyState = (): IResponse => {
             setErrorMessage("値を入力してください。");
           } else if (e.message == "roomId is not found") {
             setErrorMessage("ルームIDが無効です。");
+          } else if (e.message == "room is full") {
+            setErrorMessage("ルームが満員です。");
           }
         });
       }

--- a/src/services/RoomSync/DBOperator/DBOperator.ts
+++ b/src/services/RoomSync/DBOperator/DBOperator.ts
@@ -96,6 +96,28 @@ export const getMemberAsync = async (roomId: string, memberId: string) => {
 };
 
 /**
+ * ルーム内のメンバー数を取得する
+ * @param roomId ルームID
+ * @returns メンバー数
+ */
+export const getMemberCountAsync = async (roomId: string) => {
+  if (roomId == "") return;
+
+  //roomIdはBase32なのでエンコードしてから使用する
+  const encodedRoomId = EncodeRoomId(roomId);
+
+  //DBからGET
+  const ss = await get(child(MembersRef(), encodedRoomId));
+  const data = ss.val();
+
+  //ルームが存在しない場合はundefined
+  if (!data) return;
+
+  const members = Object.entries(data);
+  return members.length;
+};
+
+/**
  * ルーム情報を追加する
  * @param roomInfo ルーム情報
  * @returns IDとルーム情報


### PR DESCRIPTION
# チケット
- [フレンド対戦モードで５人以上入ることができるバグを修正](https://www.notion.so/053781ed048b4d4e96d4e649726b2078)

# 変更内容
- ルーム入室処理の前に、ルーム内のメンバー数のチェック処理を追加
    - メンバー数が4人未満の場合のみ、入室処理を実行
    - メンバー数が既に4人の場合は、エラーメッセージを表示
<img width="1630" alt="image" src="https://user-images.githubusercontent.com/35371161/219434620-b9ddd294-6e5c-457f-b455-ad7b27422e85.png">

# レビュー項目
- 5人以上入ろうとしても入室できない && エラーメッセージが表示される