### PR TITLE
フリーコーディング（ルーム対戦）デザイン実装

### DIFF
--- a/src/components/Avatar/AvatarStyle.tsx
+++ b/src/components/Avatar/AvatarStyle.tsx
@@ -119,8 +119,13 @@ const pinkStyle = css`
 `;
 
 const grayStyle = css`
-  border-color: ${avatar.gray.border};
-  background-color: ${avatar.gray.background};
+  .avatar_main {
+    background-color: ${avatar.gray.background};
+  }
+
+  .avatar_circle {
+    border-color: ${avatar.gray.border};
+  }
 `;
 
 const userStyle = css``;

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -34,6 +34,13 @@ MediumPink.args = {
   size: "M",
 };
 
+export const Medium2Black = Template.bind({});
+Medium2Black.args = {
+  ...Default.args,
+  color: "black",
+  size: "M2",
+};
+
 export const SmallGreen = Template.bind({});
 SmallGreen.args = {
   ...Default.args,

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -23,6 +23,12 @@ describe("<Button />", () => {
     ).toBeTruthy();
   });
 
+  it("render test blue M2", () => {
+    expect(
+      render(<Button color="blue" size="M2" status="default" value="テスト" />)
+    ).toBeTruthy();
+  });
+
   it("render test pink L", () => {
     expect(
       render(<Button color="pink" size="L" status="default" value="テスト" />)

--- a/src/components/Button/ButtonStyle.tsx
+++ b/src/components/Button/ButtonStyle.tsx
@@ -6,7 +6,7 @@ import { Icon16 } from "types/utils";
 
 export type ButtonStyleProps = {
   color?: "black" | "blue" | "pink" | "green" | "white";
-  size?: "S" | "M" | "L";
+  size?: "S" | "M" | "M2" | "L";
   status?: "default" | "disabled";
 };
 
@@ -97,6 +97,18 @@ const mStyle = css`
   }
 `;
 
+const m2Style = css`
+  border-radius: 16px;
+  padding-bottom: 6px;
+  font-size: 24px;
+
+  .frame {
+    border-radius: 16px;
+    padding: 12px 40px;
+    ${FlexGap({ gap: "10px", direction: "column" })}
+  }
+`;
+
 const lStyle = css`
   border-radius: 24px;
   padding-bottom: 8px;
@@ -138,6 +150,7 @@ export const ButtonStyle = styled.button<ButtonStyleProps>`
 
   ${({ size }) => size == "S" && sStyle}
   ${({ size }) => size == "M" && mStyle}
+  ${({ size }) => size == "M2" && m2Style}
   ${({ size }) => size == "L" && lStyle}
 
   ${({ status }) => status == "disabled" && disabledStyle}

--- a/src/pages/Code/Coding/Coding.test.tsx
+++ b/src/pages/Code/Coding/Coding.test.tsx
@@ -73,7 +73,7 @@ const initialState: IResponse = {
   //     },
   //   ],
   // },
-  backLinkRoute: "/",
+  backLinkState: { label: "", route: "" },
   showSetting: false,
   toggleSettingHandler: jest.fn(),
   closePanelHandler: jest.fn(),

--- a/src/pages/Code/Coding/Coding.tsx
+++ b/src/pages/Code/Coding/Coding.tsx
@@ -52,7 +52,7 @@ export const CodeCoding: React.FC<Props> = () => {
     changeStep,
     linkToNotion,
     // その他
-    backLinkRoute,
+    backLinkState,
   } = useCodingState();
   if (loading) {
     return (
@@ -66,9 +66,9 @@ export const CodeCoding: React.FC<Props> = () => {
     <CodingStyle>
       <Background color="blue" />
       <WhiteBackground showUnity={showUnity} />
-      <BackLink to={backLinkRoute}>
+      <BackLink to={backLinkState.route}>
         <IconButton Icon={ArrowLeft} />
-        <span>モード選択に戻る</span>
+        <span>{backLinkState.label}</span>
       </BackLink>
       <ContainerWrap show={showLog || showSetting}>
         <ContainerMain>

--- a/src/pages/Code/Coding/__snapshots__/Coding.test.tsx.snap
+++ b/src/pages/Code/Coding/__snapshots__/Coding.test.tsx.snap
@@ -10,13 +10,13 @@ Array [
       showUnity={true}
     />
     <Styled(Component)
-      to="/"
+      to=""
     >
       <IconButton
         Icon={[Function]}
       />
       <span>
-        モード選択に戻る
+        
       </span>
     </Styled(Component)>
     <styled.div

--- a/src/pages/Code/Coding/hooks/useCodeHooks.tsx
+++ b/src/pages/Code/Coding/hooks/useCodeHooks.tsx
@@ -52,6 +52,11 @@ const initialState: CodeState = {
   buttonType: "hidden",
 };
 
+type BackLinkState = {
+  label: string;
+  route: string;
+};
+
 export type IResponse = {
   // 状態変数
   /** ページの状態 */
@@ -86,7 +91,7 @@ export type IResponse = {
   toggleLogHandler: () => void;
   toggleSettingHandler: () => void;
   closePanelHandler: () => void;
-  backLinkRoute: string;
+  backLinkState: BackLinkState;
   changeStep: (step: number) => void;
   linkToNotion: () => void;
 };
@@ -95,18 +100,32 @@ export const useCodingState = (): IResponse => {
   // コードID取得
   const { codeId, beforePage } = useParams<string>();
 
-  const [backLinkRoute, setBackLinkRoute] = useState<string>("");
+  const [backLinkState, setBackLinkState] = useState<BackLinkState>({
+    label: "モード選択に戻る",
+    route: "/event/select-mode",
+  });
 
   useEffect(() => {
-    setBackLinkRoute(
-      beforePage == "eventAI"
-        ? "/event/select-ai"
-        : beforePage == "codes"
-        ? "/codes"
-        : beforePage == "eventTrain"
-        ? "/event/select-mode"
-        : ""
-    );
+    switch (beforePage) {
+      case "eventAI":
+        setBackLinkState({ label: "AI選択に戻る", route: "/event/select-ai" });
+        break;
+      case "codes":
+        setBackLinkState({ label: "コード一覧に戻る", route: "/codes" });
+        break;
+      case "eventTrain":
+        setBackLinkState({
+          label: "モード選択に戻る",
+          route: "/event/select-mode",
+        });
+        break;
+      case "selectCode":
+        setBackLinkState({
+          label: "待機部屋に戻る",
+          route: "/room-match/waiting-room?modal=on",
+        });
+        break;
+    }
   }, []);
 
   // hooksの宣言
@@ -272,7 +291,7 @@ export const useCodingState = (): IResponse => {
     unityContext,
     buttonHandler,
     toggleLogHandler,
-    backLinkRoute,
+    backLinkState,
     toggleSettingHandler,
     showSetting,
     closePanelHandler,

--- a/src/pages/RoomMatch/WaitingRoom/WaitingRoom.test.tsx
+++ b/src/pages/RoomMatch/WaitingRoom/WaitingRoom.test.tsx
@@ -100,6 +100,7 @@ const state: IResponse = {
   },
   selectedCode: code1,
   onChangeSelectedCode: jest.fn(),
+  onStartToEditCode: jest.fn(),
   showCodeSelectModal: false,
   openCodeSelectModal: () => {},
   closeCodeSelectModal: () => {},

--- a/src/pages/RoomMatch/WaitingRoom/WaitingRoom.tsx
+++ b/src/pages/RoomMatch/WaitingRoom/WaitingRoom.tsx
@@ -39,6 +39,7 @@ export const RoomMatchWaitingRoom: React.FC<Props> = () => {
     onChangeSelectedCode,
     openCodeSelectModal,
     closeCodeSelectModal,
+    onStartToEditCode,
     showCodeSelectModal,
     startBtnDisabled,
     readyBtnDisabled,
@@ -77,10 +78,12 @@ export const RoomMatchWaitingRoom: React.FC<Props> = () => {
             codeList={code.codes}
             onSelect={onChangeSelectedCode}
             onClose={closeCodeSelectModal}
+            onStartToEdit={onStartToEditCode}
             selected={selectedCode}
             onReady={() => {
               if (!ready) readyBtnHandler();
             }}
+            startToEditBtnDisabled={readyBtnDisabled}
             readyBtnDisabled={readyBtnDisabled}
           />
         )}

--- a/src/pages/RoomMatch/WaitingRoom/components/CodeSelect.tsx
+++ b/src/pages/RoomMatch/WaitingRoom/components/CodeSelect.tsx
@@ -1,6 +1,5 @@
+import React, { FC } from "react";
 import { CodeType } from "hooks/CodeAPIHooks/useFetchCodes";
-import { FC } from "react";
-import React from "react";
 import { Button } from "components/Button/Button";
 import {
   BackBlur,
@@ -24,7 +23,9 @@ interface CodeSelectProps {
   onSelect: (code: CodeType) => void;
   onClose: () => void;
   onReady: () => void;
+  onStartToEdit: () => void;
   readyBtnDisabled: boolean;
+  startToEditBtnDisabled: boolean;
 }
 
 export const CodeSelect: FC<CodeSelectProps> = ({
@@ -33,7 +34,9 @@ export const CodeSelect: FC<CodeSelectProps> = ({
   onClose,
   onSelect,
   onReady,
+  onStartToEdit,
   readyBtnDisabled,
+  startToEditBtnDisabled,
 }) => {
   return (
     <>
@@ -71,17 +74,23 @@ export const CodeSelect: FC<CodeSelectProps> = ({
             )}
           </LeftPanel>
           <RightPanel>
-            {
-              <CodeBlock
-                code={selected ? selected.codeContent : ""}
-                editorProps={{}}
-                fontSize={18}
-                height={546}
-              />
-            }
+            <CodeBlock
+              code={selected ? selected.codeContent : ""}
+              editorProps={{}}
+              fontSize={18}
+              height={546}
+            />
           </RightPanel>
         </Container>
         <BottomPanel>
+          <Button
+            color="pink"
+            icon={null}
+            onClick={onStartToEdit}
+            size="M2"
+            status={startToEditBtnDisabled ? "disabled" : "default"}
+            value="へんしゅう"
+          />
           <Button
             color="blue"
             icon={null}
@@ -89,7 +98,7 @@ export const CodeSelect: FC<CodeSelectProps> = ({
               onReady();
               onClose();
             }}
-            size="M"
+            size="M2"
             status={readyBtnDisabled ? "disabled" : "default"}
             value="このコードで対戦する"
           />

--- a/src/pages/RoomMatch/WaitingRoom/components/CodeSelectStyle.tsx
+++ b/src/pages/RoomMatch/WaitingRoom/components/CodeSelectStyle.tsx
@@ -7,6 +7,7 @@ import {
   GRAY_90,
   WHITE,
 } from "styles/colors";
+import { FlexGap } from "styles/FlexGap/FlexGap";
 
 export const BackBlur = styled.div`
   position: absolute;
@@ -126,6 +127,7 @@ export const BottomPanel = styled.div`
   display: flex;
   justify-content: flex-end;
   width: 100%;
+  ${FlexGap({ gap: "16px", direction: "row" })}
 `;
 
 export const Close = styled.div`

--- a/src/pages/RoomMatch/WaitingRoom/hooks/useWaitingRoomState.test.ts
+++ b/src/pages/RoomMatch/WaitingRoom/hooks/useWaitingRoomState.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react-hooks";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { useWaitingRoomState } from "./useWaitingRoomState";
 import { useRoomSync } from "hooks/RoomSyncHooks/useRoomSync";
@@ -16,6 +16,7 @@ const useRoomSyncMock = useRoomSync as jest.Mock;
 const useNavigateMock = useNavigate as jest.Mock;
 const useFetchCodesMock = useFetchCodes as jest.Mock;
 const useSelectorMock = useSelector as jest.Mock;
+const useSearchParamsMock = useSearchParams as jest.Mock;
 
 const users: { [id: string]: UserState } = {
   userid1: {
@@ -107,6 +108,11 @@ describe("useWaitingRoomState", () => {
       unRegisterObserver: null,
       loading: false,
     });
+    useSearchParamsMock.mockReturnValue([
+      {
+        get: (paramName: string) => (paramName === "modal" ? "on" : undefined),
+      },
+    ]);
   });
   afterEach(() => {
     jest.resetAllMocks();
@@ -446,5 +452,38 @@ describe("useWaitingRoomState", () => {
 
   describe("isCopyBtnClicked", () => {
     // TODO コピー部分のテストを書きたかったが難しかったため挫折...
+  });
+
+  describe("ページ開始時にモーダルが開かれているかどうか", () => {
+    describe("modal=onがGETクエリに指定された場合", () => {
+      beforeEach(() => {
+        useSearchParamsMock.mockReturnValue([
+          {
+            get: (paramName: string) =>
+              paramName === "modal" ? "on" : undefined,
+          },
+        ]);
+      });
+
+      it("モーダルが開かれている", () => {
+        const { result } = renderHook(() => useWaitingRoomState());
+        expect(result.current.showCodeSelectModal).toBe(true);
+      });
+    });
+
+    describe("modal=onがない場合", () => {
+      beforeEach(() => {
+        useSearchParamsMock.mockReturnValue([
+          {
+            get: () => undefined,
+          },
+        ]);
+      });
+
+      it("モーダルが開かれていない", () => {
+        const { result } = renderHook(() => useWaitingRoomState());
+        expect(result.current.showCodeSelectModal).toBe(false);
+      });
+    });
   });
 });

--- a/src/pages/RoomMatch/WaitingRoom/hooks/useWaitingRoomState.ts
+++ b/src/pages/RoomMatch/WaitingRoom/hooks/useWaitingRoomState.ts
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useEffect, useState, useMemo } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { useRoomSync } from "hooks/RoomSyncHooks/useRoomSync";
 import { CodeType, useFetchCodes } from "hooks/CodeAPIHooks/useFetchCodes";
@@ -37,6 +37,7 @@ export type IResponse = {
   };
   selectedCode: CodeType | null;
   onChangeSelectedCode: (code: CodeType) => void;
+  onStartToEditCode: () => void;
   showCodeSelectModal: boolean;
   openCodeSelectModal: () => void;
   closeCodeSelectModal: () => void;
@@ -62,11 +63,17 @@ export const useWaitingRoomState = (): IResponse => {
   const [isCopyBtnClicked, setIsCopyBtnClicked] = useState(false);
   let { user } = useSelector((state: RootState) => state.user);
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const dummyUser: UserState = {
     displayName: "",
     status: "disconnect",
     ready: false,
   };
+
+  const modalOn = useMemo(
+    () => (searchParams.get("modal") === "on" ? true : false),
+    []
+  );
 
   // ユーザ状態を更新
   useEffect(() => {
@@ -107,6 +114,13 @@ export const useWaitingRoomState = (): IResponse => {
       codeId: selectedCode ? selectedCode.id : "",
     });
   }, [ready]);
+
+  // クエリパラメータにmodal=onを渡されたらモーダルを表示
+  useEffect(() => {
+    if (modalOn) {
+      setShowCodeSelectModal(true);
+    }
+  }, [modalOn]);
 
   // ホストの処理
   useEffect(() => {
@@ -169,6 +183,12 @@ export const useWaitingRoomState = (): IResponse => {
     setSelectedCode(code);
   };
 
+  const _onStartToEditCode = () => {
+    if (selectedCode) {
+      navigate(`/free-coding/${selectedCode.id}/selectCode`);
+    }
+  };
+
   //invitationURLのコピーボタン
   const _invitationBtnHandler = () => {
     if (room.invitationLink) {
@@ -222,6 +242,7 @@ export const useWaitingRoomState = (): IResponse => {
     },
     selectedCode: selectedCode,
     onChangeSelectedCode: _onChangeSelectedCode,
+    onStartToEditCode: _onStartToEditCode,
     showCodeSelectModal,
     openCodeSelectModal,
     closeCodeSelectModal,


### PR DESCRIPTION
### チケット
- [フリーコーディング（ルーム対戦）デザイン実装](https://www.notion.so/a1751d83a98843648a43556cd8fbb8c9?pvs=4)

### やったこと
- [コード選択モーダルからフリーコーディングに飛べる機能を実装](https://github.com/CodeParty2021/code_party_front/commit/b21bc61bc9297a7d38096268fda7c5773d5221ac)
  - コード選択モーダルからフリーコーディングに「へんしゅう」ボタンから飛べる
  - 戻るとモーダルが開いた状態になっている
    - 部屋にも入った状態
  - スクショ
![image](https://user-images.githubusercontent.com/26971566/223739125-a3233875-eb08-400f-86e7-20db1199d622.png)

- [ボタンのサイズを追加](https://github.com/CodeParty2021/code_party_front/commit/4d7d582a6884e9145ee110cb6262d389bf14080f)
  - M2サイズを追加
- [Avatarのデザインを修正](https://github.com/CodeParty2021/code_party_front/commit/02ce2fb653342968ff742557affff16e8a057b13)
  - おそらく #128 での修正漏れ


