### PR TITLE
実行ボタンを連打できる問題を修正

### DIFF
--- a/src/pages/Code/Coding/hooks/useCodeHooks.tsx
+++ b/src/pages/Code/Coding/hooks/useCodeHooks.tsx
@@ -99,7 +99,7 @@ export const useCodingState = (): IResponse => {
 
   // ボタンがクリックされたか
   const [hasClicked, setHasClicked] = useState<boolean>(false);
-  
+
   useEffect(() => {
     setBackLinkRoute(
       beforePage == "eventAI"

--- a/src/pages/Code/Coding/hooks/useCodeHooks.tsx
+++ b/src/pages/Code/Coding/hooks/useCodeHooks.tsx
@@ -97,6 +97,9 @@ export const useCodingState = (): IResponse => {
 
   const [backLinkRoute, setBackLinkRoute] = useState<string>("");
 
+  // ボタンがクリックされたか
+  const [hasClicked, setHasClicked] = useState<boolean>(false);
+  
   useEffect(() => {
     setBackLinkRoute(
       beforePage == "eventAI"
@@ -223,7 +226,7 @@ export const useCodingState = (): IResponse => {
   /**
    * ボタンを押した時のコールバック
    */
-  const buttonHandler = useMemo(
+  const clickEventHandler = useMemo(
     () =>
       buttonType === "toGame"
         ? execCode
@@ -232,6 +235,19 @@ export const useCodingState = (): IResponse => {
         : undefined,
     [buttonType, execCode, toEditorButtonHandler]
   );
+
+  // clickEventHandlerを1回だけ実行する
+  const buttonHandler = () => {
+    if (!clickEventHandler || hasClicked) return;
+    setHasClicked(true);
+
+    clickEventHandler();
+  };
+
+  // コード画面/ゲーム画面切り替え時にリセットして押せるように
+  useEffect(() => {
+    setHasClicked(false);
+  }, [buttonType]);
 
   /**
    * パネルの表示切り替えコールバック


### PR DESCRIPTION
## チケット
https://www.notion.so/c2ed054bced64076acebfda5bd645b6e

## 変更内容
- フリーコーディングのボタンを連打したときに、イベントハンドラを1回のみ実行するように修正