### PR TITLE
[対戦画面]min-heightを追加

### DIFF
--- a/src/pages/RoomMatch/WaitingRoom/components/CodeSelectStyle.tsx
+++ b/src/pages/RoomMatch/WaitingRoom/components/CodeSelectStyle.tsx
@@ -98,7 +98,7 @@ export const Title = styled.div`
 
 export const CodeLabel = styled.label`
   display: block;
-  height: 56px;
+  min-height: 56px;
   padding: 0 32px 0;
   width: 100%;
 
@@ -117,6 +117,7 @@ export const CodeLabel = styled.label`
 `;
 
 export const CodeInput = styled.input`
+  height:100%;
   display: none;
   &:checked + label {
     border: 3px solid ${BLUE_50};

--- a/src/pages/RoomMatch/WaitingRoom/components/CodeSelectStyle.tsx
+++ b/src/pages/RoomMatch/WaitingRoom/components/CodeSelectStyle.tsx
@@ -117,7 +117,7 @@ export const CodeLabel = styled.label`
 `;
 
 export const CodeInput = styled.input`
-  height:100%;
+  height: 100%;
   display: none;
   &:checked + label {
     border: 3px solid ${BLUE_50};


### PR DESCRIPTION
コードが増えると対戦画面のコード選択がつぶれる問題。
flexやめるかmin-heightをつけるかの二択でflex残しました。