### PR TITLE
コンパイルエラーをログに表示する

### DIFF
--- a/src/hooks/CodeAPIHooks/errors.ts
+++ b/src/hooks/CodeAPIHooks/errors.ts
@@ -1,0 +1,25 @@
+export const CODE_API_ERROR_CODES = [
+  "invalid_parameter", // 不正なパラメータ
+  "no_resource", // リソースが見つからなかった
+  "no_select_func", // select関数が見つからなかった
+  "user_code_error", // ユーザコードで何かしらのエラーが発生した
+  "code_count_shortage", // 必要なコード数が足りない
+] as const;
+
+export type CodeAPIErrorResponseType = {
+  data: {
+    errorCode: typeof CODE_API_ERROR_CODES[number];
+    detail?: string;
+  };
+};
+
+export const isCodeAPIErrorResponseType = (
+  instance: any
+): instance is CodeAPIErrorResponseType => {
+  return (
+    !!instance &&
+    "data" in instance &&
+    "errorCode" in instance["data"] &&
+    CODE_API_ERROR_CODES.includes(instance["data"]["errorCode"])
+  );
+};

--- a/src/hooks/CodeAPIHooks/useCodeAPI.ts
+++ b/src/hooks/CodeAPIHooks/useCodeAPI.ts
@@ -1,6 +1,7 @@
 import { AxiosError, AxiosResponse } from "axios";
 import { useState } from "react";
 import { axiosWithIdToken } from "axios_config";
+import { CodeAPIErrorResponseType, isCodeAPIErrorResponseType } from "./errors";
 
 export type IResponse = {
   loading: boolean;
@@ -133,6 +134,10 @@ export type PlayerState = {
 export const isPlayerState = (instance: any): instance is PlayerState => {
   return instance !== undefined && "print" in instance;
 };
+
+export type TestCodeErrorResponseType = CodeAPIErrorResponseType;
+
+export const isTestCodeErrorResponseType = isCodeAPIErrorResponseType;
 
 export const useCodeAPI = (): IResponse => {
   const [loading, setLoading] = useState<boolean>(false);
@@ -364,12 +369,19 @@ export const useCodeAPI = (): IResponse => {
         })
         .catch((err) => {
           setLoading(false);
-          const errorResponse = String(err.response.data);
-          const end = errorResponse.indexOf("Request"); //上手く検索できなかった
-          const displayText =
-            end != -1 ? errorResponse.substr(0, end) : errorResponse;
-          setError(displayText);
-          return rejects(new Error(error));
+          const errorResponse = err.response;
+
+          // 既知のエラー内容の場合
+          if (isTestCodeErrorResponseType(errorResponse)) {
+            const detail = errorResponse.data.detail;
+            setError(detail);
+            return rejects(detail);
+          } else {
+            setError(errorResponse?.data?.detail || "不明のエラー");
+            return rejects(
+              new Error(errorResponse?.data?.detail || errorResponse)
+            );
+          }
         });
     });
   };

--- a/src/hooks/CodeAPIHooks/useCodeAPI.ts
+++ b/src/hooks/CodeAPIHooks/useCodeAPI.ts
@@ -364,7 +364,11 @@ export const useCodeAPI = (): IResponse => {
         })
         .catch((err) => {
           setLoading(false);
-          setError(`testCodeAPIError${err}`);
+          const errorResponse = String(err.response.data);
+          const end = errorResponse.indexOf("Request"); //上手く検索できなかった
+          const displayText =
+            end != -1 ? errorResponse.substr(0, end) : errorResponse;
+          setError(displayText);
           return rejects(new Error(error));
         });
     });

--- a/src/hooks/CodeAPIHooks/useRunCodes.ts
+++ b/src/hooks/CodeAPIHooks/useRunCodes.ts
@@ -1,6 +1,7 @@
 import { AxiosError, AxiosResponse } from "axios";
 import { axiosWithIdToken } from "axios_config";
 import { useState } from "react";
+import { CodeAPIErrorResponseType, isCodeAPIErrorResponseType } from "./errors";
 
 export type IState = {
   data?: SimulationResult;
@@ -16,6 +17,10 @@ export type SimulationResult = {
   unityUrl: string;
   jsonId: string;
 };
+
+// エラーレスポンス
+export type RunCodeErrorResponseType = CodeAPIErrorResponseType;
+export const isRunCodeErrorResponseType = isCodeAPIErrorResponseType;
 
 export const useRunCodes = (): IResponse => {
   const [res, setRes] = useState<IState>({

--- a/src/hooks/ResultHooks/useResult.ts
+++ b/src/hooks/ResultHooks/useResult.ts
@@ -12,6 +12,7 @@ export type IResponse = {
    * 状態をリセットする
    */
   reset: () => void;
+  error: string | undefined;
 };
 
 export type ResultState = {
@@ -37,7 +38,7 @@ export const useResult = (): IResponse => {
   const [resultState, setResultState] = useState<ResultState>({
     ...initialState,
   });
-  const { testCode: testCodeOnAPI } = useCodeAPI();
+  const { testCode: testCodeOnAPI, error } = useCodeAPI();
 
   const _setIsFailed = useCallback((isFailed: boolean) => {
     setResultState((current) => ({
@@ -69,5 +70,6 @@ export const useResult = (): IResponse => {
     resultState,
     testCode,
     reset,
+    error,
   };
 };

--- a/src/pages/Code/Coding/Coding.test.tsx
+++ b/src/pages/Code/Coding/Coding.test.tsx
@@ -79,6 +79,7 @@ const initialState: IResponse = {
   closePanelHandler: jest.fn(),
   panelState: "log",
   changeStep: jest.fn(),
+  error: undefined,
 };
 
 describe("<CodeCoding />", () => {

--- a/src/pages/Code/Coding/Coding.tsx
+++ b/src/pages/Code/Coding/Coding.tsx
@@ -52,6 +52,8 @@ export const CodeCoding: React.FC<Props> = () => {
     changeStep,
     // その他
     backLinkRoute,
+    //エラーレスポンス
+    error,
   } = useCodingState();
   if (loading) {
     return (
@@ -95,6 +97,8 @@ export const CodeCoding: React.FC<Props> = () => {
           />
         </ContainerMain>
         <LogPanel onCloseButtonClick={closePanelHandler} state={panelState}>
+          {panelState == "log" &&<>
+          {error}</>}
           {turnLog &&
             panelState == "log" &&
             turnLog.map((turn, index) => {

--- a/src/pages/Code/Coding/Coding.tsx
+++ b/src/pages/Code/Coding/Coding.tsx
@@ -26,6 +26,7 @@ import { IconButton } from "components/IconButton/IconButton";
 import { ArrowLeft } from "components/icons";
 import { Loading } from "pages/Loading/Loading";
 import { SettingItems } from "./components/SettingItem/SettingItems";
+import { LogError } from "./components/LogError/LogError";
 type Props = {};
 
 export const CodeCoding: React.FC<Props> = () => {
@@ -96,7 +97,7 @@ export const CodeCoding: React.FC<Props> = () => {
           />
         </ContainerMain>
         <LogPanel onCloseButtonClick={closePanelHandler} state={panelState}>
-          {panelState == "log" && <>{error}</>}
+          {panelState == "log" && error && <LogError>{error}</LogError>}
           {turnLog &&
             panelState == "log" &&
             turnLog.map((turn, index) => {

--- a/src/pages/Code/Coding/Coding.tsx
+++ b/src/pages/Code/Coding/Coding.tsx
@@ -62,7 +62,6 @@ export const CodeCoding: React.FC<Props> = () => {
       </div>
     );
   }
-  console.log(code?.step);
   return (
     <CodingStyle>
       <Background color="blue" />
@@ -97,8 +96,7 @@ export const CodeCoding: React.FC<Props> = () => {
           />
         </ContainerMain>
         <LogPanel onCloseButtonClick={closePanelHandler} state={panelState}>
-          {panelState == "log" &&<>
-          {error}</>}
+          {panelState == "log" && <>{error}</>}
           {turnLog &&
             panelState == "log" &&
             turnLog.map((turn, index) => {

--- a/src/pages/Code/Coding/__snapshots__/Coding.test.tsx.snap
+++ b/src/pages/Code/Coding/__snapshots__/Coding.test.tsx.snap
@@ -73,6 +73,7 @@ Array [
         onCloseButtonClick={[MockFunction]}
         state="log"
       >
+        <React.Fragment />
         <LogItem
           log="aaa"
           turnNum={1}

--- a/src/pages/Code/Coding/__snapshots__/Coding.test.tsx.snap
+++ b/src/pages/Code/Coding/__snapshots__/Coding.test.tsx.snap
@@ -73,7 +73,6 @@ Array [
         onCloseButtonClick={[MockFunction]}
         state="log"
       >
-        <React.Fragment />
         <LogItem
           log="aaa"
           turnNum={1}

--- a/src/pages/Code/Coding/components/LogError/LogError.stories.tsx
+++ b/src/pages/Code/Coding/components/LogError/LogError.stories.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { LogError } from "./LogError";
+import { LogPanel } from "../LogPanel/LogPanel";
+
+export default {
+  title: "components/LogError",
+  component: LogError,
+} as ComponentMeta<typeof LogError>;
+
+const Template: ComponentStory<typeof LogError> = (args) => (
+  <LogPanel state="log">
+    <LogError {...args} />
+  </LogPanel>
+);
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/src/pages/Code/Coding/components/LogError/LogError.test.tsx
+++ b/src/pages/Code/Coding/components/LogError/LogError.test.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { LogError } from "./LogError";
+import "jest-styled-components";
+import { render } from "enzyme";
+
+describe("<LogError />", () => {
+  it("snapshot test", () => {
+    const wrapper = render(<LogError>syntax error occurred!</LogError>);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/pages/Code/Coding/components/LogError/LogError.tsx
+++ b/src/pages/Code/Coding/components/LogError/LogError.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { LogErrorStyle, LogErrorStyleProps } from "./LogErrorStyle";
+
+type Props = LogErrorStyleProps;
+
+export const LogError: React.FC<Props> = ({ children, ...styleProps }) => {
+  return (
+    <LogErrorStyle {...styleProps}>
+      <span className="log_error_label">エラーがおきました！</span>
+      <span>{children}</span>
+    </LogErrorStyle>
+  );
+};

--- a/src/pages/Code/Coding/components/LogError/LogErrorStyle.tsx
+++ b/src/pages/Code/Coding/components/LogError/LogErrorStyle.tsx
@@ -1,0 +1,31 @@
+import styled, { css } from "styled-components";
+import { RED_20, RED_50, RED_70 } from "styles/colors";
+
+export type LogErrorStyleProps = {};
+
+const defaultStyle = css`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 10px;
+
+  color: ${RED_70};
+  line-height: 160%;
+
+  background: ${RED_20}50;
+  border: 2px solid ${RED_50};
+  border-radius: 8px;
+
+  width: 100%;
+
+  .log_error_label {
+    font-size: 14px;
+    font-weight: bold;
+  }
+`;
+
+export const LogErrorStyle = styled.div<LogErrorStyleProps>`
+  ${defaultStyle}
+`;
+
+LogErrorStyle.defaultProps = {};

--- a/src/pages/Code/Coding/components/LogError/__snapshots__/LogError.test.tsx.snap
+++ b/src/pages/Code/Coding/components/LogError/__snapshots__/LogError.test.tsx.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<LogError /> snapshot test 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 10px;
+  color: #C41C3B;
+  line-height: 160%;
+  background: #FFDBE050;
+  border: 2px solid #F45D71;
+  border-radius: 8px;
+  width: 100%;
+}
+
+.c0 .log_error_label {
+  font-size: 14px;
+  font-weight: bold;
+}
+
+<div
+  class="c0"
+>
+  <span
+    class="log_error_label"
+  >
+    エラーがおきました！
+  </span>
+  <span>
+    syntax error occurred!
+  </span>
+</div>
+`;

--- a/src/pages/Code/Coding/hooks/useCodeHooks.tsx
+++ b/src/pages/Code/Coding/hooks/useCodeHooks.tsx
@@ -187,7 +187,7 @@ export const useCodingState = (): IResponse => {
     if (resultState.isFailed) {
       setSwitchDisplay("message");
       setMessageType("error");
-      setShowTurnLog(false);
+      setShowTurnLog(true); // エラー内容を見せるためにログを開く
     }
   }, [resultState.isFailed]);
 

--- a/src/pages/Code/Coding/hooks/useCodeHooks.tsx
+++ b/src/pages/Code/Coding/hooks/useCodeHooks.tsx
@@ -88,6 +88,8 @@ export type IResponse = {
   closePanelHandler: () => void;
   backLinkRoute: string;
   changeStep: (step: number) => void;
+  /** エラーレスポンス */
+  error: string | undefined;
 };
 
 export const useCodingState = (): IResponse => {
@@ -109,6 +111,7 @@ export const useCodingState = (): IResponse => {
   }, []);
 
   // hooksの宣言
+<<<<<<< HEAD
   const {
     codeState,
     createCodeDefault,
@@ -117,6 +120,11 @@ export const useCodingState = (): IResponse => {
     changeStep,
   } = useCode(codeId);
   const { resultState, testCode, reset } = useResult();
+=======
+  const { codeState, createCodeDefault, updateCodeOnlyFront, saveCode } =
+    useCode(codeId);
+  const { resultState, testCode, reset, error } = useResult();
+>>>>>>> 0dfd007 (エラーメッセージをログに表示)
   const { dummyLoadingState, startDummyLoad } = useDummyLoading(5000);
   const { monacoEditorState, handleEditorDidMount } = useMonacoEditor();
   const { unityContext, unityStatus, startGame } = useUnityGame("SquarePaint");
@@ -260,6 +268,7 @@ export const useCodingState = (): IResponse => {
     showLog: showTurnLog,
     showMessage: switchDisplay === "message" || loading,
     code: codeState.code,
+    error,
     turnLog: resultState.simulationJson?.turn,
     handleEditorDidMount,
     unityContext,

--- a/src/pages/Code/Coding/hooks/useCodeHooks.tsx
+++ b/src/pages/Code/Coding/hooks/useCodeHooks.tsx
@@ -111,7 +111,6 @@ export const useCodingState = (): IResponse => {
   }, []);
 
   // hooksの宣言
-<<<<<<< HEAD
   const {
     codeState,
     createCodeDefault,
@@ -119,12 +118,7 @@ export const useCodingState = (): IResponse => {
     saveCode,
     changeStep,
   } = useCode(codeId);
-  const { resultState, testCode, reset } = useResult();
-=======
-  const { codeState, createCodeDefault, updateCodeOnlyFront, saveCode } =
-    useCode(codeId);
   const { resultState, testCode, reset, error } = useResult();
->>>>>>> 0dfd007 (エラーメッセージをログに表示)
   const { dummyLoadingState, startDummyLoad } = useDummyLoading(5000);
   const { monacoEditorState, handleEditorDidMount } = useMonacoEditor();
   const { unityContext, unityStatus, startGame } = useUnityGame("SquarePaint");


### PR DESCRIPTION
### チケット
- [コンパイルエラーをログに表示する](https://www.notion.so/44ac3567803445ff9bebd0d83df6fede?pvs=4)

- やることが全く同じなので、下記のPRに続けて編集を加えています 🙏 
  - #138 

### やったこと

- select関数未定義の場合
  ![image](https://github.com/CodeParty2021/code_party_front/assets/26971566/7b8cee08-29ff-4fe2-8328-0d1480351628)

- 構文エラーが起きた場合
  ![image](https://github.com/CodeParty2021/code_party_front/assets/26971566/15f3a124-9b58-4494-965c-f4e4d02e47ff)




### やっていないこと
- フックのテストなどは工数が膨らむのでやっていません

### レビュー項目
- コーディングページにて、select関数が無い場合にエラーが発生し、ログパネルにエラー内容が表示されること
- コーディングページにて、構文エラーがある場合にエラーが発生し、ログパネルにエラー内容が表示されること
  - 構文エラーの行数が一致していること